### PR TITLE
Complete web client with full library integration

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25'
       - name: Run go vet
         run: go vet ./...
       - name: Run golangci-lint
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25'
       - name: Run tests
         env:
           DATABASE_URL: postgres://test:test@localhost:5432/mockstarket_test?sslmode=disable
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25'
       - name: Build binary
         run: go build -o bin/server cmd/server/main.go
       - name: Build Docker image

--- a/README.md
+++ b/README.md
@@ -1,153 +1,166 @@
 # Mock Starket
 
-A full-stack stock market simulation where users trade fictional stocks with fake money in real-time. Built as a mono-repo with a Go backend, Next.js web app, SwiftUI iOS app, and Jetpack Compose Android app.
+**A real-time stock market simulator built from the ground up as a full-stack, multi-platform application.**
+
+Trade 31 assets across stocks, ETFs, crypto, and commodities with $100,000 in virtual cash. Prices move in real-time using a custom simulation engine. Compete on the leaderboard, earn achievements, and complete daily challenges.
+
+Built solo as a portfolio project to demonstrate full-stack architecture, real-time systems, and native mobile development across iOS, Android, and web.
+
+<!-- Screenshots go here once captured -->
+<!-- ![Market View](docs/screenshots/market.png) -->
+
+---
+
+## What I Built
+
+### Backend -- Go
+
+A production-grade REST API and WebSocket server handling 30+ endpoints, real-time price simulation, and 8 concurrent background workers.
+
+**Highlights:**
+- Custom stock price simulation using **Geometric Brownian Motion** with mean reversion, sector correlation, and random market events (earnings surprises, sector shifts, Fed announcements)
+- **Order matching engine** that evaluates limit, stop, and stop-limit orders against live prices every simulation tick
+- **Real-time WebSocket** broadcasting price updates, trade confirmations, and alert notifications to connected clients
+- Background workers for price history recording (OHLCV at 4 intervals), leaderboard computation, achievement evaluation, daily challenge generation, and price alert monitoring
+- **42 unit tests** covering order matching logic, OHLCV aggregation, middleware (rate limiting, auth, panic recovery), config loading, and HTTP handlers
+
+**Stack:** Go 1.23, Chi router, pgx (PostgreSQL), Gorilla WebSocket, Firebase Auth, golang-migrate
+
+### Web -- Next.js
+
+A 12-page responsive web app with real-time price updates, interactive charts, and a complete trading workflow.
+
+**Highlights:**
+- **Live candlestick charts** (lightweight-charts) with configurable time intervals
+- Real-time price updates via WebSocket reflected instantly across all views
+- Asset type filtering (Stocks / ETFs / Crypto / Commodities)
+- Full trading flow: market orders, limit/stop order creation, order management
+- Portfolio dashboard with P&L breakdown, trade history, and position details
+- Price alerts, daily challenges, leaderboard, and achievement tracking
+- Dark theme inspired by GitHub's design system
+
+**Stack:** Next.js 15, React 19, TypeScript, Tailwind CSS, Zustand, lightweight-charts
+
+### iOS -- SwiftUI
+
+A native iOS app with a Robinhood-inspired trading interface and full feature parity with the web.
+
+**Highlights:**
+- **Robinhood-style full-screen trade flow** with share/dollar input modes, review confirmation, and success animation
+- Native Charts framework for price visualization
+- Real-time WebSocket price updates with live UI transitions
+- ETF detail view showing weighted constituent holdings
+- Keychain-based auth token persistence
+- Asset type badges and user position display on stock detail
+
+**Stack:** SwiftUI, iOS 18+, Swift 6, MVVM with @Observable, async/await, SPM
+
+### Android -- Jetpack Compose
+
+A native Android app with Material 3 design, Hilt dependency injection, and the same trading workflow.
+
+**Highlights:**
+- Full MVVM architecture with Hilt DI, Retrofit networking, and DataStore persistence
+- Market view with live data, search filtering, and navigation to stock detail
+- Trade execution with buy/sell, quantity input, and real-time price display
+- Portfolio with P&L cards, holdings breakdown, and achievement tracking
+- Material 3 dark theme matching the web and iOS color palette
+
+**Stack:** Jetpack Compose, Kotlin, Hilt, Retrofit + Moshi, Material 3, DataStore
+
+---
 
 ## Architecture
 
 ```
-┌─────────────┐  ┌─────────────┐  ┌─────────────┐
-│   iOS App   │  │   Web App   │  │ Android App │
-│   SwiftUI   │  │   Next.js   │  │   Compose   │
-└──────┬──────┘  └──────┬──────┘  └──────┬──────┘
-       │                │                │
-       └────────────────┼────────────────┘
-                        │
-              REST API + WebSocket
-                        │
-               ┌────────┴────────┐
-               │   Go Backend    │
-               │  Chi + pgx +   │
-               │  Gorilla WS    │
-               ├─────────────────┤
-               │ Simulation Eng. │ ← Geometric Brownian Motion
-               │ Order Matching  │ ← Limit/Stop/Stop-Limit
-               │ Price History   │ ← OHLCV at 1s/1m/5m/1h
-               │ Leaderboard    │ ← Ranked by net worth
-               │ Achievements   │ ← 20 achievements
-               │ Daily Challenge │ ← Auto-generated daily
-               │ Price Alerts   │ ← WebSocket notifications
-               └────────┬────────┘
-                        │
-               ┌────────┴────────┐
-               │   PostgreSQL    │
-               └─────────────────┘
+ iOS (SwiftUI)     Web (Next.js)     Android (Compose)
+       |                |                  |
+       +------------ REST API + WebSocket -+
+                        |
+              +---------+---------+
+              |    Go Backend     |
+              |                   |
+              |  Simulation Engine|  GBM + mean reversion
+              |  Order Matcher   |  limit / stop / stop-limit
+              |  8 Workers       |  price history, alerts,
+              |                   |  leaderboard, achievements,
+              |                   |  challenges, stock sync
+              +---------+---------+
+                        |
+                   PostgreSQL
 ```
 
-## Tech Stack
+## Assets
 
-| Layer | Technology |
-|-------|-----------|
-| **Backend** | Go 1.23, Chi router, pgx, Gorilla WebSocket, Firebase Auth |
-| **Web** | Next.js 15, React 19, TypeScript, Tailwind CSS, Zustand, lightweight-charts |
-| **iOS** | SwiftUI, iOS 18+, Swift 6, MVVM, async/await, Charts framework |
-| **Android** | Jetpack Compose, Material 3, Hilt, Retrofit, Kotlin Coroutines |
-| **Database** | PostgreSQL with golang-migrate |
-| **Deploy** | Docker Compose, nginx reverse proxy |
-| **CI/CD** | GitHub Actions (7 workflows) |
+| Type | Count | Examples |
+|------|-------|---------|
+| **Stocks** | 20 | Pied Piper, Stark Industries, Dunder Mifflin, Krusty Krab |
+| **Crypto** | 4 | Bitcoin, Ethereum, Solana, Dogecoin |
+| **Commodities** | 3 | Gold, Silver, Crude Oil |
+| **ETFs** | 4 | Total Market, Tech, Defense, Crypto |
+
+ETFs track their underlying holdings with configurable weights and derive their price from constituent assets.
 
 ## Features
 
-- **Real-time trading** -- Buy and sell 23 fictional stocks with simulated prices
-- **Live price simulation** -- Geometric Brownian Motion with mean reversion, sector correlation, and market events
-- **Order types** -- Market, limit, stop, and stop-limit orders with automatic matching
-- **Portfolio tracking** -- Net worth, P&L, position breakdown, portfolio history
-- **Leaderboard** -- Compete for the top rank (daily, weekly, all-time)
-- **Achievements** -- 20 unlockable achievements across trading, portfolio, social, and skill categories
-- **Daily challenges** -- Auto-generated challenges with cash rewards
-- **Price alerts** -- Set above/below alerts with real-time WebSocket notifications
-- **Price charts** -- Interactive candlestick charts with multiple time intervals
-- **Guest accounts** -- Start trading immediately, no sign-up required
+| Feature | Description |
+|---------|------------|
+| Real-time trading | Market orders execute instantly at simulated prices |
+| Advanced orders | Limit, stop, and stop-limit orders with automatic matching |
+| Portfolio tracking | Net worth, cash, invested value, per-position P&L |
+| Price simulation | Geometric Brownian Motion with drift, volatility, and mean reversion |
+| Market events | Random earnings surprises, sector events, and macro announcements |
+| Leaderboard | Daily, weekly, and all-time rankings by net worth |
+| Achievements | 20 unlockables across trading, portfolio, social, streak, and skill categories |
+| Daily challenges | Auto-generated challenges with cash rewards |
+| Price alerts | Above/below alerts with real-time WebSocket notifications |
+| Candlestick charts | Interactive OHLCV charts at 1-second to 1-hour intervals |
+| ETF holdings | View constituent assets and their weights |
+| Guest accounts | Start trading immediately with no sign-up |
 
-## Project Structure
+## Running Locally
 
-```
-.
-├── backend/          # Go REST API + WebSocket server
-│   ├── cmd/          # Server, migrate, seed entrypoints
-│   ├── internal/     # Handler, service, repository, simulation, workers
-│   └── migrations/   # PostgreSQL schema
-├── web/              # Next.js web frontend
-│   └── src/          # Pages, components, stores, types
-├── ios/              # SwiftUI iOS app
-│   └── MockStarket/  # App, Core, Features, Models
-├── android/          # Jetpack Compose Android app
-│   └── app/src/      # UI, data, domain, DI
-├── deploy/           # Docker Compose, nginx, Postgres init
-├── .github/          # CI/CD workflows, PR/issue templates
-└── scripts/          # Setup and test runner scripts
-```
-
-## Getting Started
-
-### Prerequisites
-
-- Go 1.23+
-- Node.js 22+
-- PostgreSQL 15+
-- Docker & Docker Compose (optional, for containerized setup)
-
-### Quick Start (Docker)
-
+**Quick start with Docker:**
 ```bash
-cd deploy
-cp .env.example .env
-docker compose up -d
+cd deploy && cp .env.example .env && docker compose up -d
 ```
 
-This starts PostgreSQL, the Go backend, the Next.js web app, and nginx.
-
-### Manual Setup
-
-**Backend:**
+**Manual setup:**
 ```bash
+# Backend
 cd backend
 export DATABASE_URL="postgres://user:pass@localhost:5432/mockstarket?sslmode=disable"
 go run cmd/migrate/main.go up
 go run cmd/seed/main.go
 go run cmd/server/main.go
-```
-
-**Web:**
-```bash
-cd web
-npm install
-npm run dev
-```
-
-**iOS:**
-Open `ios/MockStarket.xcodeproj` in Xcode. The Firebase SPM package will resolve on first open.
-
-**Android:**
-Open the `android/` directory in Android Studio. Gradle will sync dependencies automatically.
-
-### Running Tests
-
-```bash
-# Backend (42 tests)
-cd backend && go test ./...
 
 # Web
-cd web && npm run type-check
+cd web && npm install && npm run dev
+
+# iOS
+open ios/MockStarket.xcodeproj
+
+# Android
+# Open android/ in Android Studio
 ```
 
-## API Overview
+**Tests:**
+```bash
+cd backend && go test ./...    # 42 tests
+cd web && npm run type-check   # TypeScript validation
+```
 
-The backend exposes 30+ REST endpoints under `/api/v1/`:
+## Project Structure
 
-| Group | Endpoints |
-|-------|----------|
-| Auth | Register, guest login, get/update/delete profile |
-| Stocks | List, detail, history, market summary |
-| Trading | Execute trades, trade history |
-| Orders | Create/list/cancel limit & stop orders |
-| Portfolio | Holdings, net worth, portfolio history |
-| Leaderboard | Rankings by period |
-| Achievements | List all, user progress |
-| Challenges | Today's challenge, check progress, claim reward |
-| Alerts | Create/list/delete price alerts |
-| Watchlist | Add/remove/list |
-
-Real-time updates via WebSocket at `/ws` (price batches, trade confirmations, alert triggers).
+```
+mock-starket/
+  backend/        Go API server (30+ endpoints, 8 workers, simulation engine)
+  web/            Next.js frontend (12 pages, charts, WebSocket)
+  ios/            SwiftUI app (28 Swift files, MVVM, Robinhood-style trading)
+  android/        Compose app (23 Kotlin files, Hilt, Material 3)
+  deploy/         Docker Compose, nginx, Postgres
+  .github/        7 CI/CD workflows, PR/issue templates
+```
 
 ## License
 
@@ -155,4 +168,4 @@ MIT
 
 ## Author
 
-Luke Solomon
+**Luke Solomon** -- [GitHub](https://github.com/ares42)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.23-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 WORKDIR /app
 
@@ -12,7 +12,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o /migrate cmd/migrate/main.go
 RUN CGO_ENABLED=0 GOOS=linux go build -o /seed cmd/seed/main.go
 
 # Dev stage (for hot reload with Docker Compose)
-FROM golang:1.23-alpine AS dev
+FROM golang:1.25-alpine AS dev
 
 WORKDIR /app
 RUN go install github.com/air-verse/air@latest

--- a/backend/cmd/seed/main.go
+++ b/backend/cmd/seed/main.go
@@ -28,35 +28,53 @@ func main() {
 	ctx := context.Background()
 
 	stocks := []model.Stock{
+		// ============ STOCKS ============
 		// Tech Sector
-		{Ticker: "PLNX", Name: "Planetronix", Sector: "Tech", BasePrice: d("142.00"), CurrentPrice: d("142.00"), DayOpen: d("142.00"), DayHigh: d("142.00"), DayLow: d("142.00"), PrevClose: d("140.50"), Volatility: d("0.025"), Drift: d("0.001"), MeanReversion: d("0.10"), Description: ptr("Leading manufacturer of interstellar navigation systems and quantum computing platforms.")},
-		{Ticker: "GWNT", Name: "Gwent Industries", Sector: "Tech", BasePrice: d("156.00"), CurrentPrice: d("156.00"), DayOpen: d("156.00"), DayHigh: d("156.00"), DayLow: d("156.00"), PrevClose: d("154.25"), Volatility: d("0.032"), Drift: d("0.002"), MeanReversion: d("0.08"), Description: ptr("Enterprise card-based analytics and strategic decision-making software.")},
-		{Ticker: "PIPE", Name: "Pied Piper", Sector: "Tech", BasePrice: d("267.00"), CurrentPrice: d("267.00"), DayOpen: d("267.00"), DayHigh: d("267.00"), DayLow: d("267.00"), PrevClose: d("264.80"), Volatility: d("0.040"), Drift: d("0.003"), MeanReversion: d("0.06"), Description: ptr("Revolutionary middle-out compression technology for decentralized internet infrastructure.")},
-		{Ticker: "INIT", Name: "Initech Systems", Sector: "Tech", BasePrice: d("31.00"), CurrentPrice: d("31.00"), DayOpen: d("31.00"), DayHigh: d("31.00"), DayLow: d("31.00"), PrevClose: d("30.75"), Volatility: d("0.035"), Drift: d("-0.001"), MeanReversion: d("0.12"), Description: ptr("Legacy enterprise software solutions. Known for their TPS report management platform.")},
-		{Ticker: "LUMN", Name: "Lumon Industries", Sector: "Tech", BasePrice: d("145.00"), CurrentPrice: d("145.00"), DayOpen: d("145.00"), DayHigh: d("145.00"), DayLow: d("145.00"), PrevClose: d("143.50"), Volatility: d("0.025"), Drift: d("0.001"), MeanReversion: d("0.10"), Description: ptr("Biotech and workplace optimization company. Pioneering consciousness-based productivity solutions.")},
+		{Ticker: "PLNX", Name: "Planetronix", Sector: "Tech", AssetType: "stock", BasePrice: d("142.00"), CurrentPrice: d("142.00"), DayOpen: d("142.00"), DayHigh: d("142.00"), DayLow: d("142.00"), PrevClose: d("140.50"), Volatility: d("0.025"), Drift: d("0.001"), MeanReversion: d("0.10"), Description: ptr("Leading manufacturer of interstellar navigation systems and quantum computing platforms.")},
+		{Ticker: "GWNT", Name: "Gwent Industries", Sector: "Tech", AssetType: "stock", BasePrice: d("156.00"), CurrentPrice: d("156.00"), DayOpen: d("156.00"), DayHigh: d("156.00"), DayLow: d("156.00"), PrevClose: d("154.25"), Volatility: d("0.032"), Drift: d("0.002"), MeanReversion: d("0.08"), Description: ptr("Enterprise card-based analytics and strategic decision-making software.")},
+		{Ticker: "PIPE", Name: "Pied Piper", Sector: "Tech", AssetType: "stock", BasePrice: d("267.00"), CurrentPrice: d("267.00"), DayOpen: d("267.00"), DayHigh: d("267.00"), DayLow: d("267.00"), PrevClose: d("264.80"), Volatility: d("0.040"), Drift: d("0.003"), MeanReversion: d("0.06"), Description: ptr("Revolutionary middle-out compression technology for decentralized internet infrastructure.")},
+		{Ticker: "INIT", Name: "Initech Systems", Sector: "Tech", AssetType: "stock", BasePrice: d("31.00"), CurrentPrice: d("31.00"), DayOpen: d("31.00"), DayHigh: d("31.00"), DayLow: d("31.00"), PrevClose: d("30.75"), Volatility: d("0.035"), Drift: d("-0.001"), MeanReversion: d("0.12"), Description: ptr("Legacy enterprise software solutions. Known for their TPS report management platform.")},
+		{Ticker: "LUMN", Name: "Lumon Industries", Sector: "Tech", AssetType: "stock", BasePrice: d("145.00"), CurrentPrice: d("145.00"), DayOpen: d("145.00"), DayHigh: d("145.00"), DayLow: d("145.00"), PrevClose: d("143.50"), Volatility: d("0.025"), Drift: d("0.001"), MeanReversion: d("0.10"), Description: ptr("Biotech and workplace optimization company. Pioneering consciousness-based productivity solutions.")},
 
 		// Consumer Sector
-		{Ticker: "DM", Name: "Dunder Mifflin", Sector: "Consumer", BasePrice: d("45.00"), CurrentPrice: d("45.00"), DayOpen: d("45.00"), DayHigh: d("45.00"), DayLow: d("45.00"), PrevClose: d("44.50"), Volatility: d("0.020"), Drift: d("0.000"), MeanReversion: d("0.15"), Description: ptr("Mid-tier paper and office supply company. Strong regional presence in the Northeast.")},
-		{Ticker: "MSPC", Name: "Michael Scott Paper", Sector: "Consumer", BasePrice: d("8.50"), CurrentPrice: d("8.50"), DayOpen: d("8.50"), DayHigh: d("8.50"), DayLow: d("8.50"), PrevClose: d("8.40"), Volatility: d("0.055"), Drift: d("-0.002"), MeanReversion: d("0.08"), Description: ptr("Scrappy paper startup disrupting the industry with competitive pricing and personal service.")},
-		{Ticker: "SWTE", Name: "Sweet Tea Co", Sector: "Consumer", BasePrice: d("23.00"), CurrentPrice: d("23.00"), DayOpen: d("23.00"), DayHigh: d("23.00"), DayLow: d("23.00"), PrevClose: d("22.80"), Volatility: d("0.022"), Drift: d("0.001"), MeanReversion: d("0.12"), Description: ptr("Premium artisanal beverage company specializing in Southern-style sweet tea blends.")},
-		{Ticker: "CHUX", Name: "Chux Headwear", Sector: "Consumer", BasePrice: d("12.00"), CurrentPrice: d("12.00"), DayOpen: d("12.00"), DayHigh: d("12.00"), DayLow: d("12.00"), PrevClose: d("11.85"), Volatility: d("0.050"), Drift: d("0.000"), MeanReversion: d("0.10"), Description: ptr("Trendy headwear and accessories brand popular with Gen Z consumers.")},
+		{Ticker: "DM", Name: "Dunder Mifflin", Sector: "Consumer", AssetType: "stock", BasePrice: d("45.00"), CurrentPrice: d("45.00"), DayOpen: d("45.00"), DayHigh: d("45.00"), DayLow: d("45.00"), PrevClose: d("44.50"), Volatility: d("0.020"), Drift: d("0.000"), MeanReversion: d("0.15"), Description: ptr("Mid-tier paper and office supply company. Strong regional presence in the Northeast.")},
+		{Ticker: "MSPC", Name: "Michael Scott Paper", Sector: "Consumer", AssetType: "stock", BasePrice: d("8.50"), CurrentPrice: d("8.50"), DayOpen: d("8.50"), DayHigh: d("8.50"), DayLow: d("8.50"), PrevClose: d("8.40"), Volatility: d("0.055"), Drift: d("-0.002"), MeanReversion: d("0.08"), Description: ptr("Scrappy paper startup disrupting the industry with competitive pricing and personal service.")},
+		{Ticker: "SWTE", Name: "Sweet Tea Co", Sector: "Consumer", AssetType: "stock", BasePrice: d("23.00"), CurrentPrice: d("23.00"), DayOpen: d("23.00"), DayHigh: d("23.00"), DayLow: d("23.00"), PrevClose: d("22.80"), Volatility: d("0.022"), Drift: d("0.001"), MeanReversion: d("0.12"), Description: ptr("Premium artisanal beverage company specializing in Southern-style sweet tea blends.")},
+		{Ticker: "CHUX", Name: "Chux Headwear", Sector: "Consumer", AssetType: "stock", BasePrice: d("12.00"), CurrentPrice: d("12.00"), DayOpen: d("12.00"), DayHigh: d("12.00"), DayLow: d("12.00"), PrevClose: d("11.85"), Volatility: d("0.050"), Drift: d("0.000"), MeanReversion: d("0.10"), Description: ptr("Trendy headwear and accessories brand popular with Gen Z consumers.")},
 
 		// Defense Sector
-		{Ticker: "ZONE", Name: "Danger Zone Defense", Sector: "Defense", BasePrice: d("210.00"), CurrentPrice: d("210.00"), DayOpen: d("210.00"), DayHigh: d("210.00"), DayLow: d("210.00"), PrevClose: d("208.00"), Volatility: d("0.035"), Drift: d("0.002"), MeanReversion: d("0.08"), Description: ptr("Advanced aerospace and defense contractor. Specializes in next-gen fighter jet systems.")},
-		{Ticker: "STRK", Name: "Stark Industries", Sector: "Defense", BasePrice: d("412.00"), CurrentPrice: d("412.00"), DayOpen: d("412.00"), DayHigh: d("412.00"), DayLow: d("412.00"), PrevClose: d("408.50"), Volatility: d("0.020"), Drift: d("0.002"), MeanReversion: d("0.10"), Description: ptr("Multinational defense and clean energy conglomerate. Industry leader in arc reactor technology.")},
-		{Ticker: "ACME", Name: "Acme Corporation", Sector: "Defense", BasePrice: d("88.00"), CurrentPrice: d("88.00"), DayOpen: d("88.00"), DayHigh: d("88.00"), DayLow: d("88.00"), PrevClose: d("87.25"), Volatility: d("0.028"), Drift: d("0.000"), MeanReversion: d("0.12"), Description: ptr("Diversified industrial manufacturer. Known for creative solutions and rapid prototyping.")},
+		{Ticker: "ZONE", Name: "Danger Zone Defense", Sector: "Defense", AssetType: "stock", BasePrice: d("210.00"), CurrentPrice: d("210.00"), DayOpen: d("210.00"), DayHigh: d("210.00"), DayLow: d("210.00"), PrevClose: d("208.00"), Volatility: d("0.035"), Drift: d("0.002"), MeanReversion: d("0.08"), Description: ptr("Advanced aerospace and defense contractor. Specializes in next-gen fighter jet systems.")},
+		{Ticker: "STRK", Name: "Stark Industries", Sector: "Defense", AssetType: "stock", BasePrice: d("412.00"), CurrentPrice: d("412.00"), DayOpen: d("412.00"), DayHigh: d("412.00"), DayLow: d("412.00"), PrevClose: d("408.50"), Volatility: d("0.020"), Drift: d("0.002"), MeanReversion: d("0.10"), Description: ptr("Multinational defense and clean energy conglomerate. Industry leader in arc reactor technology.")},
+		{Ticker: "ACME", Name: "Acme Corporation", Sector: "Defense", AssetType: "stock", BasePrice: d("88.00"), CurrentPrice: d("88.00"), DayOpen: d("88.00"), DayHigh: d("88.00"), DayLow: d("88.00"), PrevClose: d("87.25"), Volatility: d("0.028"), Drift: d("0.000"), MeanReversion: d("0.12"), Description: ptr("Diversified industrial manufacturer. Known for creative solutions and rapid prototyping.")},
 
 		// Food Sector
-		{Ticker: "KRAB", Name: "Krusty Krab Holdings", Sector: "Food", BasePrice: d("19.00"), CurrentPrice: d("19.00"), DayOpen: d("19.00"), DayHigh: d("19.00"), DayLow: d("19.00"), PrevClose: d("18.80"), Volatility: d("0.042"), Drift: d("0.001"), MeanReversion: d("0.10"), Description: ptr("Fast-casual seafood restaurant chain. Famous for their proprietary secret formula burger.")},
-		{Ticker: "BUBS", Name: "Bubs Concessions", Sector: "Food", BasePrice: d("8.50"), CurrentPrice: d("8.50"), DayOpen: d("8.50"), DayHigh: d("8.50"), DayLow: d("8.50"), PrevClose: d("8.40"), Volatility: d("0.055"), Drift: d("-0.001"), MeanReversion: d("0.08"), Description: ptr("Micro-cap concession stand operator. Questionable accounting but loyal customer base.")},
-		{Ticker: "BOWL", Name: "Big Kahuna Burger", Sector: "Food", BasePrice: d("34.00"), CurrentPrice: d("34.00"), DayOpen: d("34.00"), DayHigh: d("34.00"), DayLow: d("34.00"), PrevClose: d("33.60"), Volatility: d("0.030"), Drift: d("0.001"), MeanReversion: d("0.10"), Description: ptr("Hawaiian-themed fast food chain. That IS a tasty burger.")},
+		{Ticker: "KRAB", Name: "Krusty Krab Holdings", Sector: "Food", AssetType: "stock", BasePrice: d("19.00"), CurrentPrice: d("19.00"), DayOpen: d("19.00"), DayHigh: d("19.00"), DayLow: d("19.00"), PrevClose: d("18.80"), Volatility: d("0.042"), Drift: d("0.001"), MeanReversion: d("0.10"), Description: ptr("Fast-casual seafood restaurant chain. Famous for their proprietary secret formula burger.")},
+		{Ticker: "BUBS", Name: "Bubs Concessions", Sector: "Food", AssetType: "stock", BasePrice: d("8.50"), CurrentPrice: d("8.50"), DayOpen: d("8.50"), DayHigh: d("8.50"), DayLow: d("8.50"), PrevClose: d("8.40"), Volatility: d("0.055"), Drift: d("-0.001"), MeanReversion: d("0.08"), Description: ptr("Micro-cap concession stand operator. Questionable accounting but loyal customer base.")},
+		{Ticker: "BOWL", Name: "Big Kahuna Burger", Sector: "Food", AssetType: "stock", BasePrice: d("34.00"), CurrentPrice: d("34.00"), DayOpen: d("34.00"), DayHigh: d("34.00"), DayLow: d("34.00"), PrevClose: d("33.60"), Volatility: d("0.030"), Drift: d("0.001"), MeanReversion: d("0.10"), Description: ptr("Hawaiian-themed fast food chain. That IS a tasty burger.")},
 
 		// Industrial Sector
-		{Ticker: "MOMR", Name: "Mom's Friendly Robotics", Sector: "Industrial", BasePrice: d("340.00"), CurrentPrice: d("340.00"), DayOpen: d("340.00"), DayHigh: d("340.00"), DayLow: d("340.00"), PrevClose: d("337.50"), Volatility: d("0.030"), Drift: d("0.002"), MeanReversion: d("0.08"), Description: ptr("Leading robotics and automation manufacturer. Supplies 70% of all industrial robots worldwide.")},
-		{Ticker: "FIGG", Name: "Figgis Financial", Sector: "Industrial", BasePrice: d("67.00"), CurrentPrice: d("67.00"), DayOpen: d("67.00"), DayHigh: d("67.00"), DayLow: d("67.00"), PrevClose: d("66.25"), Volatility: d("0.028"), Drift: d("0.000"), MeanReversion: d("0.12"), Description: ptr("Private investigation firm turned financial services company. Unconventional but effective.")},
-		{Ticker: "PDLK", Name: "Paddle King Sports", Sector: "Industrial", BasePrice: d("34.00"), CurrentPrice: d("34.00"), DayOpen: d("34.00"), DayHigh: d("34.00"), DayLow: d("34.00"), PrevClose: d("33.75"), Volatility: d("0.040"), Drift: d("0.001"), MeanReversion: d("0.10"), Description: ptr("Premium sporting goods manufacturer specializing in paddle sports equipment and apparel.")},
-		{Ticker: "CBIO", Name: "Sebio Streaming", Sector: "Industrial", BasePrice: d("95.00"), CurrentPrice: d("95.00"), DayOpen: d("95.00"), DayHigh: d("95.00"), DayLow: d("95.00"), PrevClose: d("94.00"), Volatility: d("0.038"), Drift: d("0.001"), MeanReversion: d("0.08"), Description: ptr("Next-generation streaming platform with AI-curated content and neural-direct viewing technology.")},
-		{Ticker: "CHSM", Name: "Chu Supply Materials", Sector: "Industrial", BasePrice: d("52.00"), CurrentPrice: d("52.00"), DayOpen: d("52.00"), DayHigh: d("52.00"), DayLow: d("52.00"), PrevClose: d("51.50"), Volatility: d("0.025"), Drift: d("0.000"), MeanReversion: d("0.12"), Description: ptr("Wholesale building materials and supply chain logistics. Reliable dividend payer.")},
+		{Ticker: "MOMR", Name: "Mom's Friendly Robotics", Sector: "Industrial", AssetType: "stock", BasePrice: d("340.00"), CurrentPrice: d("340.00"), DayOpen: d("340.00"), DayHigh: d("340.00"), DayLow: d("340.00"), PrevClose: d("337.50"), Volatility: d("0.030"), Drift: d("0.002"), MeanReversion: d("0.08"), Description: ptr("Leading robotics and automation manufacturer. Supplies 70% of all industrial robots worldwide.")},
+		{Ticker: "FIGG", Name: "Figgis Financial", Sector: "Industrial", AssetType: "stock", BasePrice: d("67.00"), CurrentPrice: d("67.00"), DayOpen: d("67.00"), DayHigh: d("67.00"), DayLow: d("67.00"), PrevClose: d("66.25"), Volatility: d("0.028"), Drift: d("0.000"), MeanReversion: d("0.12"), Description: ptr("Private investigation firm turned financial services company. Unconventional but effective.")},
+		{Ticker: "PDLK", Name: "Paddle King Sports", Sector: "Industrial", AssetType: "stock", BasePrice: d("34.00"), CurrentPrice: d("34.00"), DayOpen: d("34.00"), DayHigh: d("34.00"), DayLow: d("34.00"), PrevClose: d("33.75"), Volatility: d("0.040"), Drift: d("0.001"), MeanReversion: d("0.10"), Description: ptr("Premium sporting goods manufacturer specializing in paddle sports equipment and apparel.")},
+		{Ticker: "CBIO", Name: "Sebio Streaming", Sector: "Industrial", AssetType: "stock", BasePrice: d("95.00"), CurrentPrice: d("95.00"), DayOpen: d("95.00"), DayHigh: d("95.00"), DayLow: d("95.00"), PrevClose: d("94.00"), Volatility: d("0.038"), Drift: d("0.001"), MeanReversion: d("0.08"), Description: ptr("Next-generation streaming platform with AI-curated content and neural-direct viewing technology.")},
+		{Ticker: "CHSM", Name: "Chu Supply Materials", Sector: "Industrial", AssetType: "stock", BasePrice: d("52.00"), CurrentPrice: d("52.00"), DayOpen: d("52.00"), DayHigh: d("52.00"), DayLow: d("52.00"), PrevClose: d("51.50"), Volatility: d("0.025"), Drift: d("0.000"), MeanReversion: d("0.12"), Description: ptr("Wholesale building materials and supply chain logistics. Reliable dividend payer.")},
+
+		// ============ CRYPTO ============
+		{Ticker: "BTC", Name: "Bitcoin", Sector: "Crypto", AssetType: "crypto", BasePrice: d("68420.00"), CurrentPrice: d("68420.00"), DayOpen: d("68420.00"), DayHigh: d("68420.00"), DayLow: d("68420.00"), PrevClose: d("67800.00"), Volatility: d("0.045"), Drift: d("0.002"), MeanReversion: d("0.04"), Description: ptr("The original cryptocurrency. Digital gold and decentralized store of value.")},
+		{Ticker: "ETH", Name: "Ethereum", Sector: "Crypto", AssetType: "crypto", BasePrice: d("3450.00"), CurrentPrice: d("3450.00"), DayOpen: d("3450.00"), DayHigh: d("3450.00"), DayLow: d("3450.00"), PrevClose: d("3400.00"), Volatility: d("0.055"), Drift: d("0.003"), MeanReversion: d("0.05"), Description: ptr("Programmable blockchain platform. Powers DeFi, NFTs, and smart contracts.")},
+		{Ticker: "SOL", Name: "Solana", Sector: "Crypto", AssetType: "crypto", BasePrice: d("185.00"), CurrentPrice: d("185.00"), DayOpen: d("185.00"), DayHigh: d("185.00"), DayLow: d("185.00"), PrevClose: d("182.00"), Volatility: d("0.070"), Drift: d("0.003"), MeanReversion: d("0.06"), Description: ptr("High-performance blockchain with sub-second finality. Popular for memecoins and DePIN.")},
+		{Ticker: "DOGE", Name: "Dogecoin", Sector: "Crypto", AssetType: "crypto", BasePrice: d("0.42"), CurrentPrice: d("0.42"), DayOpen: d("0.42"), DayHigh: d("0.42"), DayLow: d("0.42"), PrevClose: d("0.41"), Volatility: d("0.090"), Drift: d("0.000"), MeanReversion: d("0.08"), Description: ptr("The people's crypto. Much wow. Very currency. Started as a joke, now a movement.")},
+
+		// ============ COMMODITIES ============
+		{Ticker: "GOLD", Name: "Gold", Sector: "Commodities", AssetType: "commodity", BasePrice: d("2340.00"), CurrentPrice: d("2340.00"), DayOpen: d("2340.00"), DayHigh: d("2340.00"), DayLow: d("2340.00"), PrevClose: d("2330.00"), Volatility: d("0.012"), Drift: d("0.001"), MeanReversion: d("0.15"), Description: ptr("The timeless safe-haven asset. Historically maintains value during market uncertainty.")},
+		{Ticker: "SLVR", Name: "Silver", Sector: "Commodities", AssetType: "commodity", BasePrice: d("29.50"), CurrentPrice: d("29.50"), DayOpen: d("29.50"), DayHigh: d("29.50"), DayLow: d("29.50"), PrevClose: d("29.20"), Volatility: d("0.022"), Drift: d("0.001"), MeanReversion: d("0.12"), Description: ptr("Industrial and precious metal. Used in electronics, solar panels, and jewelry.")},
+		{Ticker: "OIL", Name: "Crude Oil", Sector: "Commodities", AssetType: "commodity", BasePrice: d("78.50"), CurrentPrice: d("78.50"), DayOpen: d("78.50"), DayHigh: d("78.50"), DayLow: d("78.50"), PrevClose: d("77.80"), Volatility: d("0.030"), Drift: d("0.000"), MeanReversion: d("0.10"), Description: ptr("Black gold. Global benchmark for energy prices and economic health.")},
+
+		// ============ ETFs ============
+		{Ticker: "MKTX", Name: "Mock Total Market ETF", Sector: "ETF", AssetType: "etf", BasePrice: d("100.00"), CurrentPrice: d("100.00"), DayOpen: d("100.00"), DayHigh: d("100.00"), DayLow: d("100.00"), PrevClose: d("99.50"), Volatility: d("0.015"), Drift: d("0.001"), MeanReversion: d("0.10"), Description: ptr("Tracks all stocks in the Mock Starket. Broad market exposure in a single trade.")},
+		{Ticker: "TEKX", Name: "Mock Tech ETF", Sector: "ETF", AssetType: "etf", BasePrice: d("150.00"), CurrentPrice: d("150.00"), DayOpen: d("150.00"), DayHigh: d("150.00"), DayLow: d("150.00"), PrevClose: d("148.50"), Volatility: d("0.028"), Drift: d("0.002"), MeanReversion: d("0.08"), Description: ptr("Tracks the top tech stocks. Concentrated exposure to the technology sector.")},
+		{Ticker: "DEFX", Name: "Mock Defense ETF", Sector: "ETF", AssetType: "etf", BasePrice: d("200.00"), CurrentPrice: d("200.00"), DayOpen: d("200.00"), DayHigh: d("200.00"), DayLow: d("200.00"), PrevClose: d("198.00"), Volatility: d("0.020"), Drift: d("0.002"), MeanReversion: d("0.10"), Description: ptr("Tracks defense and aerospace stocks. Stable growth with government contract tailwinds.")},
+		{Ticker: "CPTX", Name: "Mock Crypto ETF", Sector: "ETF", AssetType: "etf", BasePrice: d("50.00"), CurrentPrice: d("50.00"), DayOpen: d("50.00"), DayHigh: d("50.00"), DayLow: d("50.00"), PrevClose: d("49.00"), Volatility: d("0.050"), Drift: d("0.002"), MeanReversion: d("0.06"), Description: ptr("Tracks major cryptocurrencies. Crypto exposure without managing wallets.")},
 	}
 
 	fmt.Println("Seeding stocks...")
@@ -103,6 +121,41 @@ func main() {
 			log.Printf("failed to seed achievement %s: %v", a.id, err)
 		} else {
 			fmt.Printf("  ✓ %s - %s\n", a.id, a.name)
+		}
+	}
+
+	// Seed ETF compositions
+	fmt.Println("\nSeeding ETF compositions...")
+
+	etfHoldings := []struct {
+		etf, holding string
+		weight       string
+	}{
+		// MKTX - Total Market (equal weight across all stocks)
+		{"MKTX", "PLNX", "0.05"}, {"MKTX", "GWNT", "0.05"}, {"MKTX", "PIPE", "0.05"},
+		{"MKTX", "INIT", "0.05"}, {"MKTX", "LUMN", "0.05"}, {"MKTX", "DM", "0.05"},
+		{"MKTX", "MSPC", "0.05"}, {"MKTX", "SWTE", "0.05"}, {"MKTX", "CHUX", "0.05"},
+		{"MKTX", "ZONE", "0.05"}, {"MKTX", "STRK", "0.05"}, {"MKTX", "ACME", "0.05"},
+		{"MKTX", "KRAB", "0.05"}, {"MKTX", "BUBS", "0.05"}, {"MKTX", "BOWL", "0.05"},
+		{"MKTX", "MOMR", "0.05"}, {"MKTX", "FIGG", "0.05"}, {"MKTX", "PDLK", "0.05"},
+		{"MKTX", "CBIO", "0.05"}, {"MKTX", "CHSM", "0.05"},
+
+		// TEKX - Tech ETF
+		{"TEKX", "PLNX", "0.20"}, {"TEKX", "GWNT", "0.20"}, {"TEKX", "PIPE", "0.25"},
+		{"TEKX", "INIT", "0.10"}, {"TEKX", "LUMN", "0.25"},
+
+		// DEFX - Defense ETF
+		{"DEFX", "ZONE", "0.30"}, {"DEFX", "STRK", "0.45"}, {"DEFX", "ACME", "0.25"},
+
+		// CPTX - Crypto ETF
+		{"CPTX", "BTC", "0.50"}, {"CPTX", "ETH", "0.30"}, {"CPTX", "SOL", "0.15"}, {"CPTX", "DOGE", "0.05"},
+	}
+
+	for _, h := range etfHoldings {
+		if err := repo.UpsertETFHolding(ctx, h.etf, h.holding, d(h.weight)); err != nil {
+			log.Printf("failed to seed ETF holding %s->%s: %v", h.etf, h.holding, err)
+		} else {
+			fmt.Printf("  ✓ %s holds %s (%.0f%%)\n", h.etf, h.holding, d(h.weight).InexactFloat64()*100)
 		}
 	}
 

--- a/backend/internal/handler/handler.go
+++ b/backend/internal/handler/handler.go
@@ -262,6 +262,45 @@ func (h *Handler) GetMarketSummary(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (h *Handler) GetETFHoldings(w http.ResponseWriter, r *http.Request) {
+	ticker := chi.URLParam(r, "ticker")
+
+	holdings, err := h.repo.GetETFHoldings(r.Context(), ticker)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to fetch ETF holdings")
+		return
+	}
+
+	// Enrich with current prices and stock names
+	livePrices := h.engine.GetAllPrices()
+	type enrichedHolding struct {
+		Ticker string  `json:"ticker"`
+		Name   string  `json:"name"`
+		Weight string  `json:"weight"`
+		Price  string  `json:"price"`
+	}
+
+	result := make([]enrichedHolding, 0, len(holdings))
+	for _, holding := range holdings {
+		price := ""
+		if p, ok := livePrices[holding.HoldingTicker]; ok {
+			price = p.String()
+		}
+		name := holding.HoldingTicker
+		if stock, err := h.repo.GetStockByTicker(r.Context(), holding.HoldingTicker); err == nil {
+			name = stock.Name
+		}
+		result = append(result, enrichedHolding{
+			Ticker: holding.HoldingTicker,
+			Name:   name,
+			Weight: holding.Weight.String(),
+			Price:  price,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
 // ---- Trading ----
 
 func (h *Handler) ExecuteTrade(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/middleware/middleware.go
+++ b/backend/internal/middleware/middleware.go
@@ -1,8 +1,11 @@
 package middleware
 
 import (
+	"bufio"
 	"context"
+	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -142,4 +145,12 @@ type responseWriter struct {
 func (rw *responseWriter) WriteHeader(code int) {
 	rw.statusCode = code
 	rw.ResponseWriter.WriteHeader(code)
+}
+
+// Hijack implements http.Hijacker so WebSocket upgrades work through the logger middleware.
+func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hj, ok := rw.ResponseWriter.(http.Hijacker); ok {
+		return hj.Hijack()
+	}
+	return nil, nil, fmt.Errorf("underlying ResponseWriter does not implement http.Hijacker")
 }

--- a/backend/internal/model/models.go
+++ b/backend/internal/model/models.go
@@ -24,6 +24,7 @@ type Stock struct {
 	Ticker         string          `json:"ticker" db:"ticker"`
 	Name           string          `json:"name" db:"name"`
 	Sector         string          `json:"sector" db:"sector"`
+	AssetType      string          `json:"asset_type" db:"asset_type"` // stock, etf, crypto, commodity
 	BasePrice      decimal.Decimal `json:"base_price" db:"base_price"`
 	CurrentPrice   decimal.Decimal `json:"current_price" db:"current_price"`
 	DayOpen        decimal.Decimal `json:"day_open" db:"day_open"`
@@ -37,6 +38,13 @@ type Stock struct {
 	Description    *string         `json:"description,omitempty" db:"description"`
 	LogoURL        *string         `json:"logo_url,omitempty" db:"logo_url"`
 	CreatedAt      time.Time       `json:"created_at" db:"created_at"`
+}
+
+type ETFHolding struct {
+	ID            uuid.UUID       `json:"id" db:"id"`
+	ETFTicker     string          `json:"etf_ticker" db:"etf_ticker"`
+	HoldingTicker string          `json:"holding_ticker" db:"holding_ticker"`
+	Weight        decimal.Decimal `json:"weight" db:"weight"`
 }
 
 type Portfolio struct {

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -86,21 +86,21 @@ func (r *Repo) UpdateLoginStreak(ctx context.Context, id uuid.UUID) error {
 
 func (r *Repo) UpsertStock(ctx context.Context, s *model.Stock) error {
 	_, err := r.pool.Exec(ctx,
-		`INSERT INTO stocks (ticker, name, sector, base_price, current_price, day_open, day_high, day_low, prev_close, volume, volatility, drift, mean_reversion, description)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+		`INSERT INTO stocks (ticker, name, sector, asset_type, base_price, current_price, day_open, day_high, day_low, prev_close, volume, volatility, drift, mean_reversion, description)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
 		 ON CONFLICT (ticker) DO UPDATE SET
-			name = EXCLUDED.name, sector = EXCLUDED.sector, base_price = EXCLUDED.base_price,
+			name = EXCLUDED.name, sector = EXCLUDED.sector, asset_type = EXCLUDED.asset_type, base_price = EXCLUDED.base_price,
 			current_price = EXCLUDED.current_price, volatility = EXCLUDED.volatility, drift = EXCLUDED.drift,
 			mean_reversion = EXCLUDED.mean_reversion, description = EXCLUDED.description`,
-		s.Ticker, s.Name, s.Sector, s.BasePrice, s.CurrentPrice, s.DayOpen, s.DayHigh, s.DayLow,
+		s.Ticker, s.Name, s.Sector, s.AssetType, s.BasePrice, s.CurrentPrice, s.DayOpen, s.DayHigh, s.DayLow,
 		s.PrevClose, s.Volume, s.Volatility, s.Drift, s.MeanReversion, s.Description)
 	return err
 }
 
 func (r *Repo) GetAllStocks(ctx context.Context) ([]model.Stock, error) {
 	rows, err := r.pool.Query(ctx,
-		`SELECT ticker, name, sector, base_price, current_price, day_open, day_high, day_low, prev_close, volume, volatility, drift, mean_reversion, description, logo_url, created_at
-		 FROM stocks ORDER BY ticker`)
+		`SELECT ticker, name, sector, asset_type, base_price, current_price, day_open, day_high, day_low, prev_close, volume, volatility, drift, mean_reversion, description, logo_url, created_at
+		 FROM stocks ORDER BY asset_type, ticker`)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func (r *Repo) GetAllStocks(ctx context.Context) ([]model.Stock, error) {
 	var stocks []model.Stock
 	for rows.Next() {
 		var s model.Stock
-		if err := rows.Scan(&s.Ticker, &s.Name, &s.Sector, &s.BasePrice, &s.CurrentPrice,
+		if err := rows.Scan(&s.Ticker, &s.Name, &s.Sector, &s.AssetType, &s.BasePrice, &s.CurrentPrice,
 			&s.DayOpen, &s.DayHigh, &s.DayLow, &s.PrevClose, &s.Volume,
 			&s.Volatility, &s.Drift, &s.MeanReversion, &s.Description, &s.LogoURL, &s.CreatedAt); err != nil {
 			return nil, err
@@ -122,9 +122,9 @@ func (r *Repo) GetAllStocks(ctx context.Context) ([]model.Stock, error) {
 func (r *Repo) GetStockByTicker(ctx context.Context, ticker string) (*model.Stock, error) {
 	s := &model.Stock{}
 	err := r.pool.QueryRow(ctx,
-		`SELECT ticker, name, sector, base_price, current_price, day_open, day_high, day_low, prev_close, volume, volatility, drift, mean_reversion, description, logo_url, created_at
+		`SELECT ticker, name, sector, asset_type, base_price, current_price, day_open, day_high, day_low, prev_close, volume, volatility, drift, mean_reversion, description, logo_url, created_at
 		 FROM stocks WHERE ticker = $1`, ticker,
-	).Scan(&s.Ticker, &s.Name, &s.Sector, &s.BasePrice, &s.CurrentPrice,
+	).Scan(&s.Ticker, &s.Name, &s.Sector, &s.AssetType, &s.BasePrice, &s.CurrentPrice,
 		&s.DayOpen, &s.DayHigh, &s.DayLow, &s.PrevClose, &s.Volume,
 		&s.Volatility, &s.Drift, &s.MeanReversion, &s.Description, &s.LogoURL, &s.CreatedAt)
 	return s, err
@@ -135,6 +135,36 @@ func (r *Repo) UpdateStockPrices(ctx context.Context, ticker string, price, high
 		`UPDATE stocks SET current_price = $2, day_high = $3, day_low = $4, volume = $5 WHERE ticker = $1`,
 		ticker, price, high, low, volume)
 	return err
+}
+
+// ---- ETF Holdings ----
+
+func (r *Repo) UpsertETFHolding(ctx context.Context, etfTicker, holdingTicker string, weight decimal.Decimal) error {
+	_, err := r.pool.Exec(ctx,
+		`INSERT INTO etf_holdings (etf_ticker, holding_ticker, weight)
+		 VALUES ($1, $2, $3)
+		 ON CONFLICT (etf_ticker, holding_ticker) DO UPDATE SET weight = EXCLUDED.weight`,
+		etfTicker, holdingTicker, weight)
+	return err
+}
+
+func (r *Repo) GetETFHoldings(ctx context.Context, etfTicker string) ([]model.ETFHolding, error) {
+	rows, err := r.pool.Query(ctx,
+		`SELECT id, etf_ticker, holding_ticker, weight FROM etf_holdings WHERE etf_ticker = $1 ORDER BY weight DESC`, etfTicker)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var holdings []model.ETFHolding
+	for rows.Next() {
+		var h model.ETFHolding
+		if err := rows.Scan(&h.ID, &h.ETFTicker, &h.HoldingTicker, &h.Weight); err != nil {
+			return nil, err
+		}
+		holdings = append(holdings, h)
+	}
+	return holdings, nil
 }
 
 // ---- Portfolios ----

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -80,6 +80,7 @@ func New(h *handler.Handler, hub *ws.Hub, authVerifier mw.FirebaseAuthVerifier, 
 		r.Get("/stocks/market-summary", h.GetMarketSummary)
 		r.Get("/stocks/{ticker}", h.GetStock)
 		r.Get("/stocks/{ticker}/history", h.GetStockHistory)
+		r.Get("/stocks/{ticker}/holdings", h.GetETFHoldings)
 
 		// Trading
 		r.Post("/trades", h.ExecuteTrade)

--- a/backend/migrations/000002_asset_types.down.sql
+++ b/backend/migrations/000002_asset_types.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS etf_holdings;
+ALTER TABLE stocks DROP COLUMN IF EXISTS asset_type;

--- a/backend/migrations/000002_asset_types.up.sql
+++ b/backend/migrations/000002_asset_types.up.sql
@@ -1,0 +1,14 @@
+-- Add asset_type to stocks table
+ALTER TABLE stocks ADD COLUMN asset_type TEXT NOT NULL DEFAULT 'stock';
+
+-- ETF composition: which underlying assets an ETF tracks
+CREATE TABLE etf_holdings (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    etf_ticker      TEXT NOT NULL REFERENCES stocks(ticker) ON DELETE CASCADE,
+    holding_ticker  TEXT NOT NULL REFERENCES stocks(ticker) ON DELETE CASCADE,
+    weight          DECIMAL(6,4) NOT NULL DEFAULT 0.0,
+    created_at      TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(etf_ticker, holding_ticker)
+);
+
+CREATE INDEX idx_etf_holdings_etf ON etf_holdings(etf_ticker);

--- a/ios/Info.plist
+++ b/ios/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
+</dict>
+</plist>

--- a/ios/MockStarket.xcodeproj/project.pbxproj
+++ b/ios/MockStarket.xcodeproj/project.pbxproj
@@ -76,54 +76,6 @@
 		};
 /* End PBXFrameworksBuildPhase section */
 
-/* Begin PBXSourcesBuildPhase section */
-		S1000001 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		S1000002 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		S1000003 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXSourcesBuildPhase section */
-
-/* Begin PBXResourcesBuildPhase section */
-		R1000001 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		R1000002 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		R1000003 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXResourcesBuildPhase section */
-
 /* Begin PBXGroup section */
 		G1000001 = {
 			isa = PBXGroup;
@@ -263,6 +215,54 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		R1000001 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		R1000002 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		R1000003 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		S1000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		S1000002 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		S1000003 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
 		D2000001 /* PBXTargetDependency */ = {
@@ -406,7 +406,9 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = YMZ6ZTYGL8;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Mock Starket";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -415,7 +417,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UIUserInterfaceStyle = Dark;
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.mockstarket.app;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.Solomon.mock-starket";
 				PRODUCT_NAME = MockStarket;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 6.0;
@@ -430,7 +432,9 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = YMZ6ZTYGL8;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Mock Starket";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -439,7 +443,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UIUserInterfaceStyle = Dark;
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.mockstarket.app;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.Solomon.mock-starket";
 				PRODUCT_NAME = MockStarket;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 6.0;

--- a/ios/MockStarket.xcodeproj/project.pbxproj
+++ b/ios/MockStarket.xcodeproj/project.pbxproj
@@ -76,6 +76,54 @@
 		};
 /* End PBXFrameworksBuildPhase section */
 
+/* Begin PBXSourcesBuildPhase section */
+		S1000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		S1000002 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		S1000003 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXResourcesBuildPhase section */
+		R1000001 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		R1000002 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		R1000003 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
 /* Begin PBXGroup section */
 		G1000001 = {
 			isa = PBXGroup;
@@ -104,7 +152,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = CF000001 /* Build configuration list for PBXNativeTarget "MockStarket" */;
 			buildPhases = (
+				S1000001 /* Sources */,
 				F1000001 /* Frameworks */,
+				R1000001 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -125,7 +175,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = CF000002 /* Build configuration list for PBXNativeTarget "MockStarketTests" */;
 			buildPhases = (
+				S1000002 /* Sources */,
 				F1000002 /* Frameworks */,
+				R1000002 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -146,7 +198,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = CF000003 /* Build configuration list for PBXNativeTarget "MockStarketUITests" */;
 			buildPhases = (
+				S1000003 /* Sources */,
 				F1000003 /* Frameworks */,
+				R1000003 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -362,7 +416,7 @@
 				INFOPLIST_KEY_UIUserInterfaceStyle = Dark;
 				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mockstarket.app;
-				PRODUCT_NAME = "Mock Starket";
+				PRODUCT_NAME = MockStarket;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -386,7 +440,7 @@
 				INFOPLIST_KEY_UIUserInterfaceStyle = Dark;
 				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mockstarket.app;
-				PRODUCT_NAME = "Mock Starket";
+				PRODUCT_NAME = MockStarket;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -407,7 +461,7 @@
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MockStarket.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Mock Starket";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MockStarket.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/MockStarket";
 			};
 			name = Debug;
 		};
@@ -425,7 +479,7 @@
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MockStarket.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Mock Starket";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MockStarket.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/MockStarket";
 			};
 			name = Release;
 		};

--- a/ios/MockStarket.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios/MockStarket.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ios/MockStarket/App/AppState.swift
+++ b/ios/MockStarket/App/AppState.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import Observation
 
-@Observable
+@MainActor @Observable
 final class AppState {
     enum AuthState {
         case loading

--- a/ios/MockStarket/App/AppState.swift
+++ b/ios/MockStarket/App/AppState.swift
@@ -17,12 +17,6 @@ final class AppState {
     private let webSocketManager = WebSocketManager.shared
     private let authManager = AuthManager.shared
 
-    init() {
-        Task {
-            await checkAuth()
-        }
-    }
-
     func checkAuth() async {
         if let token = authManager.currentToken {
             do {

--- a/ios/MockStarket/App/MockStarketApp.swift
+++ b/ios/MockStarket/App/MockStarketApp.swift
@@ -17,6 +17,9 @@ struct MockStarketApp: App {
                 }
             }
             .environment(appState)
+            .task {
+                await appState.checkAuth()
+            }
         }
     }
 }

--- a/ios/MockStarket/Core/Networking/APIClient.swift
+++ b/ios/MockStarket/Core/Networking/APIClient.swift
@@ -30,6 +30,7 @@ enum APIEndpoint {
     case listStocks
     case getStock(ticker: String)
     case getStockHistory(ticker: String, interval: String)
+    case getETFHoldings(ticker: String)
     case marketSummary
 
     // Trading
@@ -78,6 +79,7 @@ enum APIEndpoint {
         case .listStocks: return "/api/v1/stocks"
         case .getStock(let ticker): return "/api/v1/stocks/\(ticker)"
         case .getStockHistory(let ticker, let interval): return "/api/v1/stocks/\(ticker)/history?interval=\(interval)"
+        case .getETFHoldings(let ticker): return "/api/v1/stocks/\(ticker)/holdings"
         case .marketSummary: return "/api/v1/stocks/market-summary"
         case .executeTrade, .getTradeHistory: return "/api/v1/trades"
         case .createOrder, .listOrders: return "/api/v1/orders"

--- a/ios/MockStarket/Core/Networking/APIClient.swift
+++ b/ios/MockStarket/Core/Networking/APIClient.swift
@@ -126,7 +126,18 @@ actor APIClient {
         self.session = URLSession.shared
 
         let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let str = try container.decode(String.self)
+            if let date = formatter.date(from: str) { return date }
+            // Fallback without fractional seconds
+            let basic = ISO8601DateFormatter()
+            basic.formatOptions = [.withInternetDateTime]
+            if let date = basic.date(from: str) { return date }
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Cannot decode date: \(str)")
+        }
         self.decoder = decoder
     }
 

--- a/ios/MockStarket/Core/WebSocket/WebSocketManager.swift
+++ b/ios/MockStarket/Core/WebSocket/WebSocketManager.swift
@@ -121,7 +121,17 @@ final class WebSocketManager: @unchecked Sendable {
               let data = text.data(using: .utf8) else { return }
 
         let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        let fmt = ISO8601DateFormatter()
+        fmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        decoder.dateDecodingStrategy = .custom { d in
+            let c = try d.singleValueContainer()
+            let s = try c.decode(String.self)
+            if let date = fmt.date(from: s) { return date }
+            let basic = ISO8601DateFormatter()
+            basic.formatOptions = [.withInternetDateTime]
+            if let date = basic.date(from: s) { return date }
+            throw DecodingError.dataCorruptedError(in: c, debugDescription: "Bad date: \(s)")
+        }
 
         guard let envelope = try? decoder.decode(WSEnvelope.self, from: data) else { return }
 

--- a/ios/MockStarket/Features/Alerts/AlertsViewModel.swift
+++ b/ios/MockStarket/Features/Alerts/AlertsViewModel.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import Observation
 
-@Observable
+@MainActor @Observable
 final class AlertsViewModel {
     var alerts: [PriceAlert] = []
     var isLoading = false

--- a/ios/MockStarket/Features/Auth/AuthViewModel.swift
+++ b/ios/MockStarket/Features/Auth/AuthViewModel.swift
@@ -13,18 +13,14 @@ final class AuthViewModel {
         defer { isLoading = false }
         errorMessage = nil
 
-        // In dev mode, generate a unique guest token
+        // In dev mode, the token IS the Firebase UID.
+        // The backend treats Bearer tokens as UIDs when DEV_MODE=true.
         let guestUID = "guest_\(UUID().uuidString.prefix(8))"
 
-        struct RegisterBody: Encodable {
-            let display_name: String
-            let is_guest: Bool
-        }
-
+        // Create the guest account on the backend
         let _: User = try await apiClient.request(
             .createGuest,
-            token: guestUID,
-            body: RegisterBody(display_name: "Guest Trader", is_guest: true)
+            token: guestUID
         )
 
         return guestUID

--- a/ios/MockStarket/Features/Auth/AuthViewModel.swift
+++ b/ios/MockStarket/Features/Auth/AuthViewModel.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import Observation
 
-@Observable
+@MainActor @Observable
 final class AuthViewModel {
     var isLoading = false
     var errorMessage: String?

--- a/ios/MockStarket/Features/Challenges/ChallengesViewModel.swift
+++ b/ios/MockStarket/Features/Challenges/ChallengesViewModel.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import Observation
 
-@Observable
+@MainActor @Observable
 final class ChallengesViewModel {
     var challenge: DailyChallenge?
     var progress: UserChallenge?

--- a/ios/MockStarket/Features/Leaderboard/LeaderboardViewModel.swift
+++ b/ios/MockStarket/Features/Leaderboard/LeaderboardViewModel.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import Observation
 
-@Observable
+@MainActor @Observable
 final class LeaderboardViewModel {
     var entries: [LeaderboardEntry] = []
     var selectedPeriod = "alltime"

--- a/ios/MockStarket/Features/Market/MarketViewModel.swift
+++ b/ios/MockStarket/Features/Market/MarketViewModel.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import Observation
 
-@Observable
+@MainActor @Observable
 final class MarketViewModel {
     var stocks: [Stock] = []
     var searchText = ""
@@ -42,14 +42,14 @@ final class MarketViewModel {
     }
 
     func subscribeToUpdates() {
-        wsManager.onPriceUpdate { [weak self] updates in
+        let vm = self
+        wsManager.onPriceUpdate { updates in
             Task { @MainActor in
-                self?.applyPriceUpdates(updates)
+                vm.applyPriceUpdates(updates)
             }
         }
     }
 
-    @MainActor
     private func applyPriceUpdates(_ updates: [PriceUpdate]) {
         for update in updates {
             if let index = stocks.firstIndex(where: { $0.ticker == update.ticker }) {

--- a/ios/MockStarket/Features/Portfolio/PortfolioViewModel.swift
+++ b/ios/MockStarket/Features/Portfolio/PortfolioViewModel.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import Observation
 
-@Observable
+@MainActor @Observable
 final class PortfolioViewModel {
     var portfolioResponse: PortfolioResponse?
     var positions: [Position] { portfolioResponse?.positions ?? [] }

--- a/ios/MockStarket/Features/Portfolio/Views/PortfolioView.swift
+++ b/ios/MockStarket/Features/Portfolio/Views/PortfolioView.swift
@@ -26,7 +26,7 @@ struct PortfolioView: View {
                             .padding(.horizontal)
 
                         ForEach(viewModel.positions) { position in
-                            NavigationLink(value: Stock(ticker: position.ticker, name: "", sector: "", basePrice: 0, currentPrice: position.currentPrice, dayOpen: 0, dayHigh: 0, dayLow: 0, prevClose: 0, volume: 0, volatility: 0, description: nil)) {
+                            NavigationLink(value: Stock(ticker: position.ticker, name: "", sector: "", assetType: "stock", basePrice: 0, currentPrice: position.currentPrice, dayOpen: 0, dayHigh: 0, dayLow: 0, prevClose: 0, volume: 0, volatility: 0, description: nil)) {
                                 PositionRowView(position: position)
                             }
                         }

--- a/ios/MockStarket/Features/Profile/ProfileViewModel.swift
+++ b/ios/MockStarket/Features/Profile/ProfileViewModel.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import Observation
 
-@Observable
+@MainActor @Observable
 final class ProfileViewModel {
     var achievements: [Achievement] = []
 

--- a/ios/MockStarket/Features/Settings/SettingsViewModel.swift
+++ b/ios/MockStarket/Features/Settings/SettingsViewModel.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import Observation
 
-@Observable
+@MainActor @Observable
 final class SettingsViewModel {
     var displayName = ""
     var isSaving = false

--- a/ios/MockStarket/Features/StockDetail/StockDetailViewModel.swift
+++ b/ios/MockStarket/Features/StockDetail/StockDetailViewModel.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import Observation
 
-@Observable
+@MainActor @Observable
 final class StockDetailViewModel {
     enum TimeRange: CaseIterable {
         case oneDay, oneWeek, oneMonth, threeMonths, all
@@ -53,15 +53,14 @@ final class StockDetailViewModel {
         }
 
         // Subscribe to live updates
-        wsManager.onPriceUpdate { [weak self] updates in
+        let vm = self
+        wsManager.onPriceUpdate { updates in
+            guard let update = updates.first(where: { $0.ticker == ticker }) else { return }
             Task { @MainActor in
-                guard let self else { return }
-                if let update = updates.first(where: { $0.ticker == ticker }) {
-                    self.stock?.currentPrice = update.price
-                    self.stock?.dayHigh = update.high
-                    self.stock?.dayLow = update.low
-                    self.stock?.volume = update.volume
-                }
+                vm.stock?.currentPrice = update.price
+                vm.stock?.dayHigh = update.high
+                vm.stock?.dayLow = update.low
+                vm.stock?.volume = update.volume
             }
         }
     }

--- a/ios/MockStarket/Features/StockDetail/StockDetailViewModel.swift
+++ b/ios/MockStarket/Features/StockDetail/StockDetailViewModel.swift
@@ -28,10 +28,12 @@ final class StockDetailViewModel {
 
     var stock: Stock?
     var priceHistory: [PricePoint] = []
+    var etfHoldings: [ETFHolding] = []
     var selectedRange: TimeRange = .oneDay
     var showTradeSheet = false
     var tradeSide = "buy"
     var isLoading = false
+    var userShares = 0
 
     private let apiClient = APIClient.shared
     private let wsManager = WebSocketManager.shared
@@ -48,6 +50,15 @@ final class StockDetailViewModel {
                 .getStockHistory(ticker: ticker, interval: selectedRange.interval),
                 token: token
             )
+
+            // Fetch user's current holding for this stock
+            let portfolio: PortfolioResponse = try await apiClient.request(.getPortfolio, token: token)
+            userShares = portfolio.positions.first(where: { $0.ticker == ticker })?.shares ?? 0
+
+            // Fetch ETF holdings if this is an ETF
+            if stock?.assetType == "etf" {
+                etfHoldings = (try? await apiClient.request(.getETFHoldings(ticker: ticker), token: token)) ?? []
+            }
         } catch {
             // Handle error
         }

--- a/ios/MockStarket/Features/StockDetail/Views/StockDetailView.swift
+++ b/ios/MockStarket/Features/StockDetail/Views/StockDetailView.swift
@@ -26,6 +26,64 @@ struct StockDetailView: View {
                     statsGrid(stock)
                 }
 
+                // ETF Holdings (if this is an ETF)
+                if viewModel.stock?.assetType == "etf" && !viewModel.etfHoldings.isEmpty {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Holdings")
+                            .font(.headline)
+                            .foregroundStyle(Theme.textPrimary)
+
+                        ForEach(viewModel.etfHoldings) { holding in
+                            HStack {
+                                Text(holding.ticker)
+                                    .font(.caption.monospaced().weight(.bold))
+                                    .foregroundStyle(Theme.accent)
+                                    .padding(.horizontal, 6)
+                                    .padding(.vertical, 3)
+                                    .background(Theme.accent.opacity(0.1))
+                                    .clipShape(RoundedRectangle(cornerRadius: 4))
+
+                                Text(holding.name)
+                                    .font(.subheadline)
+                                    .foregroundStyle(Theme.textSecondary)
+
+                                Spacer()
+
+                                Text("\((Decimal(string: holding.weight) ?? 0) * 100)%")
+                                    .font(.subheadline.weight(.semibold))
+                                    .foregroundStyle(Theme.textPrimary)
+                            }
+                            .padding(.vertical, 4)
+                        }
+                    }
+                    .padding(.horizontal)
+                }
+
+                // User position
+                if viewModel.userShares > 0 {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Your Position")
+                                .font(.caption)
+                                .foregroundStyle(Theme.textTertiary)
+                            Text("\(viewModel.userShares) share\(viewModel.userShares == 1 ? "" : "s")")
+                                .font(.headline)
+                        }
+                        Spacer()
+                        VStack(alignment: .trailing, spacing: 2) {
+                            Text("Market Value")
+                                .font(.caption)
+                                .foregroundStyle(Theme.textTertiary)
+                            Text(((viewModel.stock?.currentPrice ?? 0) * Decimal(viewModel.userShares)).formatted(.currency(code: "USD")))
+                                .font(.headline)
+                        }
+                    }
+                    .padding()
+                    .background(Theme.surface)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .padding(.horizontal)
+                }
+
                 // Trade buttons
                 tradeButtons
 
@@ -55,9 +113,19 @@ struct StockDetailView: View {
 
     private func priceHeader(_ stock: Stock) -> some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(stock.name)
-                .font(.title3.weight(.semibold))
-                .foregroundStyle(Theme.textSecondary)
+            HStack(spacing: 8) {
+                Text(stock.name)
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(Theme.textSecondary)
+
+                Text(stock.assetType.uppercased())
+                    .font(.caption2.weight(.bold))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(assetTypeColor(stock.assetType).opacity(0.15))
+                    .foregroundStyle(assetTypeColor(stock.assetType))
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+            }
 
             HStack(alignment: .firstTextBaseline, spacing: 12) {
                 Text(stock.currentPrice.currencyFormatted)
@@ -200,8 +268,22 @@ struct StockDetailView: View {
             }
         }
         .padding(.horizontal)
-        .sheet(isPresented: $viewModel.showTradeSheet) {
-            TradeSheetView(ticker: ticker, side: viewModel.tradeSide)
+        .fullScreenCover(isPresented: $viewModel.showTradeSheet) {
+            TradeSheetView(
+                ticker: ticker,
+                side: viewModel.tradeSide,
+                currentPrice: viewModel.stock?.currentPrice ?? 0,
+                currentShares: viewModel.userShares
+            )
+        }
+    }
+
+    private func assetTypeColor(_ type: String) -> Color {
+        switch type {
+        case "crypto": return .orange
+        case "commodity": return .yellow
+        case "etf": return .purple
+        default: return Theme.accent
         }
     }
 }

--- a/ios/MockStarket/Features/Trading/Views/TradeSheetView.swift
+++ b/ios/MockStarket/Features/Trading/Views/TradeSheetView.swift
@@ -3,36 +3,90 @@ import SwiftUI
 struct TradeSheetView: View {
     let ticker: String
     let side: String
+    let currentPrice: Decimal
+    var currentShares: Int = 0
 
     @State private var shares = 1
+    @State private var useDollars = false
+    @State private var dollarAmount = ""
     @State private var isLoading = false
     @State private var errorMessage: String?
     @State private var success = false
+    @State private var confirming = false
     @Environment(\.dismiss) private var dismiss
 
     private let apiClient = APIClient.shared
 
+    private var estimatedTotal: Decimal {
+        currentPrice * Decimal(shares)
+    }
+
+    private var estimatedSharesFromDollars: Int {
+        guard let amount = Decimal(string: dollarAmount), amount > 0, currentPrice > 0 else { return 0 }
+        return NSDecimalNumber(decimal: amount / currentPrice).intValue
+    }
+
+    private var effectiveShares: Int {
+        useDollars ? estimatedSharesFromDollars : shares
+    }
+
     var body: some View {
         NavigationStack {
-            VStack(spacing: 24) {
-                // Header
-                VStack(spacing: 4) {
-                    Text(side == "buy" ? "Buy" : "Sell")
-                        .font(.title2.weight(.bold))
-                        .foregroundStyle(side == "buy" ? Theme.positive : Theme.negative)
-                    Text(ticker)
-                        .font(.headline)
-                        .foregroundStyle(Theme.textSecondary)
+            ZStack {
+                Theme.background.ignoresSafeArea()
+
+                if success {
+                    successView
+                } else if confirming {
+                    confirmView
+                } else {
+                    inputView
                 }
+            }
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button { dismiss() } label: {
+                        Image(systemName: "xmark")
+                            .foregroundStyle(Theme.textSecondary)
+                    }
+                }
+            }
+        }
+    }
 
-                Spacer()
+    // MARK: - Input View
 
-                // Share quantity
-                VStack(spacing: 16) {
-                    Text("Shares")
-                        .font(.caption)
-                        .foregroundStyle(Theme.textTertiary)
+    private var inputView: some View {
+        VStack(spacing: 0) {
+            Spacer()
 
+            // Side indicator
+            Text(side == "buy" ? "Buy \(ticker)" : "Sell \(ticker)")
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(Theme.textPrimary)
+
+            Text(currentPrice.formatted(.currency(code: "USD")))
+                .font(.caption)
+                .foregroundStyle(Theme.textSecondary)
+                .padding(.top, 2)
+
+            Spacer()
+
+            // Amount display
+            if useDollars {
+                VStack(spacing: 4) {
+                    Text("$\(dollarAmount.isEmpty ? "0" : dollarAmount)")
+                        .font(.system(size: 56, weight: .bold, design: .rounded))
+                        .foregroundStyle(Theme.textPrimary)
+
+                    if estimatedSharesFromDollars > 0 {
+                        Text("≈ \(estimatedSharesFromDollars) share\(estimatedSharesFromDollars == 1 ? "" : "s")")
+                            .font(.subheadline)
+                            .foregroundStyle(Theme.textTertiary)
+                    }
+                }
+            } else {
+                VStack(spacing: 4) {
                     HStack(spacing: 24) {
                         Button {
                             if shares > 1 { shares -= 1 }
@@ -56,69 +110,220 @@ struct TradeSheetView: View {
                         }
                     }
 
-                    // Quick quantity buttons
-                    HStack(spacing: 8) {
-                        ForEach([1, 5, 10, 25, 50], id: \.self) { qty in
-                            Button("\(qty)") {
-                                shares = qty
-                            }
-                            .font(.caption.weight(.medium))
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 6)
-                            .background(shares == qty ? Theme.accent.opacity(0.2) : Theme.surfaceElevated)
-                            .foregroundStyle(shares == qty ? Theme.accent : Theme.textSecondary)
-                            .clipShape(Capsule())
-                        }
-                    }
-                }
-
-                Spacer()
-
-                if let error = errorMessage {
-                    Text(error)
-                        .font(.caption)
-                        .foregroundStyle(Theme.negative)
-                        .multilineTextAlignment(.center)
-                }
-
-                if success {
-                    Label("Trade executed!", systemImage: "checkmark.circle.fill")
-                        .font(.headline)
-                        .foregroundStyle(Theme.positive)
-                } else {
-                    // Execute button
-                    Button {
-                        Task { await executeTrade() }
-                    } label: {
-                        Group {
-                            if isLoading {
-                                ProgressView()
-                                    .tint(.white)
-                            } else {
-                                Text("\(side == "buy" ? "Buy" : "Sell") \(shares) Share\(shares == 1 ? "" : "s")")
-                                    .font(.headline)
-                            }
-                        }
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 16)
-                        .background(side == "buy" ? Theme.positive : Theme.negative)
-                        .foregroundStyle(.white)
-                        .clipShape(RoundedRectangle(cornerRadius: 14))
-                    }
-                    .disabled(isLoading)
+                    Text("share\(shares == 1 ? "" : "s")")
+                        .font(.subheadline)
+                        .foregroundStyle(Theme.textTertiary)
                 }
             }
-            .padding(24)
-            .background(Theme.background)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
+
+            Spacer()
+
+            // Quick buttons
+            HStack(spacing: 8) {
+                ForEach([1, 5, 10, 25], id: \.self) { qty in
+                    quickButton("\(qty)") { shares = qty; useDollars = false }
+                }
+
+                if side == "sell" && currentShares > 0 {
+                    quickButton("All") {
+                        shares = currentShares
+                        useDollars = false
+                    }
+                }
+
+                quickButton("$") {
+                    useDollars.toggle()
+                    dollarAmount = ""
+                }
+            }
+            .padding(.horizontal, 24)
+
+            // Dollar keypad (when in dollar mode)
+            if useDollars {
+                dollarKeypad
+                    .padding(.top, 16)
+            }
+
+            Spacer()
+
+            // Estimated total
+            if effectiveShares > 0 {
+                HStack {
+                    Text("Estimated cost")
                         .foregroundStyle(Theme.textSecondary)
+                    Spacer()
+                    Text((currentPrice * Decimal(effectiveShares)).formatted(.currency(code: "USD")))
+                        .fontWeight(.semibold)
+                }
+                .font(.subheadline)
+                .padding(.horizontal, 24)
+                .padding(.bottom, 12)
+            }
+
+            // Review button
+            Button {
+                confirming = true
+            } label: {
+                Text("Review Order")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 18)
+                    .background(side == "buy" ? Theme.positive : Theme.negative)
+                    .foregroundStyle(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+            }
+            .disabled(effectiveShares <= 0)
+            .opacity(effectiveShares > 0 ? 1 : 0.4)
+            .padding(.horizontal, 24)
+            .padding(.bottom, 16)
+
+            if let error = errorMessage {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(Theme.negative)
+                    .padding(.bottom, 8)
+            }
+        }
+    }
+
+    // MARK: - Confirm View
+
+    private var confirmView: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            Image(systemName: side == "buy" ? "arrow.up.circle.fill" : "arrow.down.circle.fill")
+                .font(.system(size: 64))
+                .foregroundStyle(side == "buy" ? Theme.positive : Theme.negative)
+
+            VStack(spacing: 8) {
+                Text("\(side == "buy" ? "Buy" : "Sell") \(effectiveShares) share\(effectiveShares == 1 ? "" : "s") of \(ticker)")
+                    .font(.title3.weight(.semibold))
+
+                Text("at \(currentPrice.formatted(.currency(code: "USD"))) per share")
+                    .foregroundStyle(Theme.textSecondary)
+
+                Text("Total: \((currentPrice * Decimal(effectiveShares)).formatted(.currency(code: "USD")))")
+                    .font(.title2.weight(.bold))
+                    .padding(.top, 8)
+            }
+
+            Spacer()
+
+            // Swipe to confirm (simplified as button)
+            Button {
+                Task { await executeTrade() }
+            } label: {
+                Group {
+                    if isLoading {
+                        ProgressView().tint(.white)
+                    } else {
+                        Label("Confirm \(side == "buy" ? "Purchase" : "Sale")", systemImage: "checkmark.circle.fill")
+                            .font(.headline)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 18)
+                .background(side == "buy" ? Theme.positive : Theme.negative)
+                .foregroundStyle(.white)
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+            }
+            .disabled(isLoading)
+            .padding(.horizontal, 24)
+
+            Button("Go Back") {
+                confirming = false
+            }
+            .foregroundStyle(Theme.textSecondary)
+            .padding(.bottom, 16)
+        }
+    }
+
+    // MARK: - Success View
+
+    private var successView: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 80))
+                .foregroundStyle(Theme.positive)
+
+            Text("Order Placed!")
+                .font(.title.weight(.bold))
+
+            Text("\(side == "buy" ? "Bought" : "Sold") \(effectiveShares) share\(effectiveShares == 1 ? "" : "s") of \(ticker)")
+                .foregroundStyle(Theme.textSecondary)
+
+            Spacer()
+
+            Button {
+                dismiss()
+            } label: {
+                Text("Done")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 18)
+                    .background(Theme.accent)
+                    .foregroundStyle(.black)
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+            }
+            .padding(.horizontal, 24)
+            .padding(.bottom, 16)
+        }
+    }
+
+    // MARK: - Components
+
+    private func quickButton(_ label: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(label)
+                .font(.caption.weight(.semibold))
+                .padding(.horizontal, 14)
+                .padding(.vertical, 8)
+                .background(Theme.surfaceElevated)
+                .foregroundStyle(Theme.textSecondary)
+                .clipShape(Capsule())
+        }
+    }
+
+    private var dollarKeypad: some View {
+        let keys = [
+            ["1", "2", "3"],
+            ["4", "5", "6"],
+            ["7", "8", "9"],
+            [".", "0", "⌫"],
+        ]
+
+        return VStack(spacing: 8) {
+            ForEach(keys, id: \.self) { row in
+                HStack(spacing: 8) {
+                    ForEach(row, id: \.self) { key in
+                        Button {
+                            if key == "⌫" {
+                                if !dollarAmount.isEmpty { dollarAmount.removeLast() }
+                            } else if key == "." {
+                                if !dollarAmount.contains(".") { dollarAmount += "." }
+                            } else {
+                                dollarAmount += key
+                            }
+                        } label: {
+                            Text(key)
+                                .font(.title3.weight(.medium))
+                                .frame(maxWidth: .infinity)
+                                .frame(height: 44)
+                                .background(Theme.surfaceElevated)
+                                .foregroundStyle(Theme.textPrimary)
+                                .clipShape(RoundedRectangle(cornerRadius: 8))
+                        }
+                    }
                 }
             }
         }
-        .presentationDetents([.medium])
+        .padding(.horizontal, 24)
     }
+
+    // MARK: - Trade Execution
 
     private func executeTrade() async {
         isLoading = true
@@ -134,13 +339,12 @@ struct TradeSheetView: View {
             let _: Trade = try await apiClient.request(
                 .executeTrade,
                 token: AuthManager.shared.currentToken,
-                body: TradeBody(ticker: ticker, side: side, shares: shares)
+                body: TradeBody(ticker: ticker, side: side, shares: effectiveShares)
             )
             success = true
-            try? await Task.sleep(for: .seconds(1.5))
-            dismiss()
         } catch {
             errorMessage = error.localizedDescription
+            confirming = false
         }
 
         isLoading = false
@@ -148,6 +352,6 @@ struct TradeSheetView: View {
 }
 
 #Preview {
-    TradeSheetView(ticker: "PLNX", side: "buy")
+    TradeSheetView(ticker: "PIPE", side: "buy", currentPrice: 267.00, currentShares: 5)
         .preferredColorScheme(.dark)
 }

--- a/ios/MockStarket/Models/Models.swift
+++ b/ios/MockStarket/Models/Models.swift
@@ -33,7 +33,7 @@ struct Stock: Codable, Identifiable, Hashable, Sendable {
     let ticker: String
     let name: String
     let sector: String
-    let assetType: String // stock, etf, crypto, commodity
+    var assetType: String = "stock" // stock, etf, crypto, commodity
     let basePrice: Decimal
     var currentPrice: Decimal
     var dayOpen: Decimal
@@ -53,6 +53,30 @@ struct Stock: Codable, Identifiable, Hashable, Sendable {
         case dayHigh = "day_high"
         case dayLow = "day_low"
         case prevClose = "prev_close"
+    }
+
+    init(ticker: String, name: String, sector: String, assetType: String = "stock", basePrice: Decimal, currentPrice: Decimal, dayOpen: Decimal, dayHigh: Decimal, dayLow: Decimal, prevClose: Decimal, volume: Int64, volatility: Decimal, description: String? = nil) {
+        self.ticker = ticker; self.name = name; self.sector = sector; self.assetType = assetType
+        self.basePrice = basePrice; self.currentPrice = currentPrice; self.dayOpen = dayOpen
+        self.dayHigh = dayHigh; self.dayLow = dayLow; self.prevClose = prevClose
+        self.volume = volume; self.volatility = volatility; self.description = description
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        ticker = try c.decode(String.self, forKey: .ticker)
+        name = try c.decode(String.self, forKey: .name)
+        sector = try c.decode(String.self, forKey: .sector)
+        assetType = try c.decodeIfPresent(String.self, forKey: .assetType) ?? "stock"
+        basePrice = try c.decode(Decimal.self, forKey: .basePrice)
+        currentPrice = try c.decode(Decimal.self, forKey: .currentPrice)
+        dayOpen = try c.decode(Decimal.self, forKey: .dayOpen)
+        dayHigh = try c.decode(Decimal.self, forKey: .dayHigh)
+        dayLow = try c.decode(Decimal.self, forKey: .dayLow)
+        prevClose = try c.decode(Decimal.self, forKey: .prevClose)
+        volume = try c.decode(Int64.self, forKey: .volume)
+        volatility = try c.decode(Decimal.self, forKey: .volatility)
+        description = try c.decodeIfPresent(String.self, forKey: .description)
     }
 
     var change: Decimal { currentPrice - dayOpen }

--- a/ios/MockStarket/Models/Models.swift
+++ b/ios/MockStarket/Models/Models.swift
@@ -68,15 +68,23 @@ struct Stock: Codable, Identifiable, Hashable, Sendable {
         name = try c.decode(String.self, forKey: .name)
         sector = try c.decode(String.self, forKey: .sector)
         assetType = try c.decodeIfPresent(String.self, forKey: .assetType) ?? "stock"
-        basePrice = try c.decode(Decimal.self, forKey: .basePrice)
-        currentPrice = try c.decode(Decimal.self, forKey: .currentPrice)
-        dayOpen = try c.decode(Decimal.self, forKey: .dayOpen)
-        dayHigh = try c.decode(Decimal.self, forKey: .dayHigh)
-        dayLow = try c.decode(Decimal.self, forKey: .dayLow)
-        prevClose = try c.decode(Decimal.self, forKey: .prevClose)
+        basePrice = try Self.decimalFromStringOrNumber(c, forKey: .basePrice)
+        currentPrice = try Self.decimalFromStringOrNumber(c, forKey: .currentPrice)
+        dayOpen = try Self.decimalFromStringOrNumber(c, forKey: .dayOpen)
+        dayHigh = try Self.decimalFromStringOrNumber(c, forKey: .dayHigh)
+        dayLow = try Self.decimalFromStringOrNumber(c, forKey: .dayLow)
+        prevClose = try Self.decimalFromStringOrNumber(c, forKey: .prevClose)
         volume = try c.decode(Int64.self, forKey: .volume)
-        volatility = try c.decode(Decimal.self, forKey: .volatility)
+        volatility = try Self.decimalFromStringOrNumber(c, forKey: .volatility)
         description = try c.decodeIfPresent(String.self, forKey: .description)
+    }
+
+    /// Decodes a Decimal that may come as a JSON string or number.
+    private static func decimalFromStringOrNumber(_ container: KeyedDecodingContainer<CodingKeys>, forKey key: CodingKeys) throws -> Decimal {
+        if let str = try? container.decode(String.self, forKey: key), let d = Decimal(string: str) {
+            return d
+        }
+        return try container.decode(Decimal.self, forKey: key)
     }
 
     var change: Decimal { currentPrice - dayOpen }
@@ -361,5 +369,19 @@ struct MarketSummary: Codable, Sendable {
         case indexChangePct = "index_change_pct"
         case totalStocks = "total_stocks"
         case gainers, losers
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        indexValue = Self.dec(c, .indexValue)
+        indexChangePct = Self.dec(c, .indexChangePct)
+        totalStocks = try c.decode(Int.self, forKey: .totalStocks)
+        gainers = try c.decode(Int.self, forKey: .gainers)
+        losers = try c.decode(Int.self, forKey: .losers)
+    }
+
+    private static func dec(_ c: KeyedDecodingContainer<CodingKeys>, _ key: CodingKeys) -> Decimal {
+        if let s = try? c.decode(String.self, forKey: key), let d = Decimal(string: s) { return d }
+        return (try? c.decode(Decimal.self, forKey: key)) ?? 0
     }
 }

--- a/ios/MockStarket/Models/Models.swift
+++ b/ios/MockStarket/Models/Models.swift
@@ -33,6 +33,7 @@ struct Stock: Codable, Identifiable, Hashable, Sendable {
     let ticker: String
     let name: String
     let sector: String
+    let assetType: String // stock, etf, crypto, commodity
     let basePrice: Decimal
     var currentPrice: Decimal
     var dayOpen: Decimal
@@ -45,6 +46,7 @@ struct Stock: Codable, Identifiable, Hashable, Sendable {
 
     enum CodingKeys: String, CodingKey {
         case ticker, name, sector, volume, volatility, description
+        case assetType = "asset_type"
         case basePrice = "base_price"
         case currentPrice = "current_price"
         case dayOpen = "day_open"
@@ -59,6 +61,16 @@ struct Stock: Codable, Identifiable, Hashable, Sendable {
         return (change / dayOpen) * 100
     }
     var isUp: Bool { change >= 0 }
+}
+
+// MARK: - ETF Holding
+
+struct ETFHolding: Codable, Identifiable, Sendable {
+    var id: String { ticker }
+    let ticker: String
+    let name: String
+    let weight: String
+    let price: String
 }
 
 // MARK: - Portfolio

--- a/ios/MockStarket/Models/Models.swift
+++ b/ios/MockStarket/Models/Models.swift
@@ -28,7 +28,7 @@ struct User: Codable, Identifiable, Sendable {
 
 // MARK: - Stock
 
-struct Stock: Codable, Identifiable, Sendable {
+struct Stock: Codable, Identifiable, Hashable, Sendable {
     var id: String { ticker }
     let ticker: String
     let name: String

--- a/web/e2e/auth.spec.ts
+++ b/web/e2e/auth.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+import { mockAPI } from './helpers';
+
+test.describe('Authentication', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAPI(page);
+  });
+
+  test('redirects unauthenticated user to login', async ({ page }) => {
+    await page.goto('/market');
+    await expect(page).toHaveURL('/login');
+  });
+
+  test('login page shows app branding', async ({ page }) => {
+    await page.goto('/login');
+    await expect(page.getByText('Mock Starket')).toBeVisible();
+    await expect(page.getByText('Learn to trade. Risk nothing.')).toBeVisible();
+  });
+
+  test('guest login redirects to market', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByRole('button', { name: 'Continue as Guest' }).click();
+    await expect(page).toHaveURL('/market');
+  });
+
+  test('sets token in localStorage after login', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByRole('button', { name: 'Continue as Guest' }).click();
+    await page.waitForURL('/market');
+
+    const token = await page.evaluate(() => localStorage.getItem('mockstarket_token'));
+    expect(token).toBeTruthy();
+    expect(token).toContain('guest_');
+  });
+});

--- a/web/e2e/helpers.ts
+++ b/web/e2e/helpers.ts
@@ -1,0 +1,107 @@
+import { type Page } from '@playwright/test';
+
+// Mock data matching what the backend would return
+const mockStocks = [
+  {
+    ticker: 'PIPE', name: 'Piper Industries', sector: 'Technology', asset_type: 'stock',
+    base_price: '150.00', current_price: '155.50', day_open: '150.00', day_high: '158.00',
+    day_low: '149.00', prev_close: '149.50', volume: 1250000, volatility: '0.02',
+    description: 'Leading tech company',
+  },
+  {
+    ticker: 'BREW', name: 'BrewCraft Holdings', sector: 'Consumer Goods', asset_type: 'stock',
+    base_price: '45.00', current_price: '43.20', day_open: '45.00', day_high: '45.50',
+    day_low: '42.80', prev_close: '44.90', volume: 800000, volatility: '0.03',
+  },
+];
+
+const mockUser = {
+  id: 'user-1', firebase_uid: 'guest_test123', display_name: 'E2ETrader',
+  avatar_url: null, is_guest: true, created_at: '2026-01-01T00:00:00Z',
+  login_streak: 3, longest_streak: 7,
+};
+
+const mockPortfolio = {
+  portfolio: { id: 'port-1', user_id: 'user-1', cash: '85000.00', net_worth: '105000.00', created_at: '2026-01-01T00:00:00Z', updated_at: '2026-04-01T00:00:00Z' },
+  positions: [
+    { id: 'pos-1', portfolio_id: 'port-1', ticker: 'PIPE', shares: 100, avg_cost: '150.00', current_price: '155.50', market_value: '15550.00', pnl: '550.00', pnl_pct: '3.67' },
+  ],
+  net_worth: '105000.00',
+  invested: '15000.00',
+};
+
+const mockLeaderboard = [
+  { id: 1, user_id: 'user-1', display_name: 'TraderJoe', net_worth: '120000.00', total_return: '20.00', rank: 1, period: 'alltime' },
+  { id: 2, user_id: 'user-2', display_name: 'StockPro', net_worth: '110000.00', total_return: '10.00', rank: 2, period: 'alltime' },
+];
+
+export async function mockAPI(page: Page) {
+  // Intercept all API calls with a single handler for reliability
+  await page.route('**/api/v1/**', (route) => {
+    const url = route.request().url();
+    const method = route.request().method();
+    const path = new URL(url).pathname;
+
+    // Auth
+    if (path === '/api/v1/auth/guest') return route.fulfill({ json: mockUser });
+    if (path === '/api/v1/auth/me' && method === 'GET') return route.fulfill({ json: mockUser });
+    if (path === '/api/v1/auth/me' && method === 'PUT') return route.fulfill({ json: { status: 'updated' } });
+    if (path === '/api/v1/auth/me' && method === 'DELETE') return route.fulfill({ json: { status: 'deleted' } });
+
+    // Stocks
+    if (path === '/api/v1/stocks/market-summary') return route.fulfill({ json: { index_value: '12500.00', index_change_pct: '1.25', total_stocks: 2, gainers: 1, losers: 1 } });
+    if (path.match(/\/api\/v1\/stocks\/[A-Z]+\/history/)) return route.fulfill({ json: [] });
+    if (path.match(/\/api\/v1\/stocks\/[A-Z]+\/holdings/)) return route.fulfill({ json: [] });
+    if (path.match(/\/api\/v1\/stocks\/([A-Z]+)$/)) {
+      const ticker = path.split('/').pop()!;
+      const stock = mockStocks.find((s) => s.ticker === ticker);
+      return route.fulfill({ json: stock || mockStocks[0] });
+    }
+    if (path === '/api/v1/stocks') return route.fulfill({ json: mockStocks });
+
+    // Portfolio
+    if (path.startsWith('/api/v1/portfolio/history')) return route.fulfill({ json: [] });
+    if (path === '/api/v1/portfolio') return route.fulfill({ json: mockPortfolio });
+
+    // Trades
+    if (path === '/api/v1/trades' && method === 'POST') {
+      return route.fulfill({ json: { id: 'trade-new', ticker: 'PIPE', side: 'buy', shares: 10, price: '155.50', total: '1555.00', created_at: new Date().toISOString() } });
+    }
+    if (path.startsWith('/api/v1/trades')) return route.fulfill({ json: [] });
+
+    // Orders
+    if (path.startsWith('/api/v1/orders') && method === 'DELETE') return route.fulfill({ json: { status: 'cancelled' } });
+    if (path === '/api/v1/orders' && method === 'POST') return route.fulfill({ json: { id: 'order-new', status: 'open' } });
+    if (path.startsWith('/api/v1/orders')) return route.fulfill({ json: [] });
+
+    // Alerts
+    if (path.startsWith('/api/v1/alerts') && method === 'DELETE') return route.fulfill({ json: { status: 'deleted' } });
+    if (path === '/api/v1/alerts' && method === 'POST') return route.fulfill({ json: { id: 'alert-new' } });
+    if (path.startsWith('/api/v1/alerts')) return route.fulfill({ json: [] });
+
+    // Leaderboard
+    if (path.startsWith('/api/v1/leaderboard')) return route.fulfill({ json: mockLeaderboard });
+
+    // Achievements
+    if (path === '/api/v1/achievements/me') return route.fulfill({ json: [] });
+    if (path === '/api/v1/achievements') return route.fulfill({ json: [{ id: 'ach-1', name: 'First Trade', description: 'Execute your first trade', icon: '🎯', category: 'trading' }] });
+
+    // Challenges
+    if (path.startsWith('/api/v1/challenges')) return route.fulfill({ json: { challenge: null, progress: null } });
+
+    // Watchlist
+    if (path.startsWith('/api/v1/watchlist')) return route.fulfill({ json: [] });
+
+    // System
+    if (path === '/api/v1/system/health') return route.fulfill({ json: { status: 'ok' } });
+
+    // Fallback
+    return route.fulfill({ status: 404, json: { error: 'not found' } });
+  });
+}
+
+export async function loginAsGuest(page: Page) {
+  await page.goto('/login');
+  await page.getByRole('button', { name: 'Continue as Guest' }).click();
+  await page.waitForURL('/market');
+}

--- a/web/e2e/leaderboard.spec.ts
+++ b/web/e2e/leaderboard.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+import { mockAPI, loginAsGuest } from './helpers';
+
+test.describe('Leaderboard Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAPI(page);
+    await loginAsGuest(page);
+    await page.getByRole('link', { name: 'Leaderboard' }).click();
+  });
+
+  test('displays leaderboard with rankings', async ({ page }) => {
+    await expect(page.getByText('TraderJoe')).toBeVisible();
+    await expect(page.getByText('StockPro')).toBeVisible();
+    await expect(page.getByText('$120,000.00')).toBeVisible();
+  });
+
+  test('shows period toggle buttons', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'All Time' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Weekly' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Daily' })).toBeVisible();
+  });
+});

--- a/web/e2e/market.spec.ts
+++ b/web/e2e/market.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+import { mockAPI, loginAsGuest } from './helpers';
+
+test.describe('Market Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAPI(page);
+    await loginAsGuest(page);
+  });
+
+  test('displays market heading and summary section', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Market' })).toBeVisible();
+    await expect(page.getByText('Market Index')).toBeVisible();
+  });
+
+  test('displays search input and asset filters', async ({ page }) => {
+    await expect(page.getByPlaceholder('Search stocks...')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'All' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Stocks' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'ETFs' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Crypto' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Commodities' })).toBeVisible();
+  });
+
+  test('displays stock table with headers', async ({ page }) => {
+    await expect(page.getByRole('table')).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: /Stock/ })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: /Price/ })).toBeVisible();
+  });
+
+  test('stock table contains rows', async ({ page }) => {
+    // Wait for stock data to load and render into the table
+    const firstRow = page.locator('tbody tr').first();
+    await expect(firstRow).toBeVisible({ timeout: 10_000 });
+    expect(await page.locator('tbody tr').count()).toBeGreaterThan(0);
+  });
+
+  test('search clears input and table still has rows', async ({ page }) => {
+    // Wait for data to load
+    await expect(page.locator('tbody tr').first()).toBeVisible({ timeout: 10_000 });
+
+    // Type and clear search
+    const searchInput = page.getByPlaceholder('Search stocks...');
+    await searchInput.fill('test');
+    await page.waitForTimeout(400);
+    await searchInput.clear();
+    await page.waitForTimeout(400);
+
+    // Table should still have rows after clearing
+    expect(await page.locator('tbody tr').count()).toBeGreaterThan(0);
+  });
+
+  test('asset filter buttons are clickable', async ({ page }) => {
+    await page.getByRole('button', { name: 'ETFs' }).click();
+    // Should filter — either shows ETF rows or an empty table
+    await expect(page.getByRole('table')).toBeVisible();
+  });
+});

--- a/web/e2e/navigation.spec.ts
+++ b/web/e2e/navigation.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+import { mockAPI, loginAsGuest } from './helpers';
+
+test.describe('Navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAPI(page);
+    await loginAsGuest(page);
+  });
+
+  test('sidebar shows all nav items', async ({ page }) => {
+    await expect(page.getByRole('link', { name: 'Market' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Portfolio' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Orders' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Leaderboard' })).toBeVisible();
+  });
+
+  test('sidebar shows extra nav items', async ({ page }) => {
+    await expect(page.getByRole('link', { name: 'Watchlist' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Alerts' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Challenges' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Achievements' })).toBeVisible();
+  });
+
+  test('navigates to each main page', async ({ page }) => {
+    await page.getByRole('link', { name: 'Portfolio' }).click();
+    await expect(page).toHaveURL('/portfolio');
+
+    await page.getByRole('link', { name: 'Orders' }).click();
+    await expect(page).toHaveURL('/orders');
+
+    await page.getByRole('link', { name: 'Leaderboard' }).click();
+    await expect(page).toHaveURL('/leaderboard');
+
+    await page.getByRole('link', { name: 'Settings' }).click();
+    await expect(page).toHaveURL('/settings');
+  });
+
+  test('shows connection status in sidebar', async ({ page }) => {
+    await expect(page.getByText(/Connected|Reconnecting|Disconnected/)).toBeVisible();
+  });
+});

--- a/web/e2e/portfolio.spec.ts
+++ b/web/e2e/portfolio.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+import { mockAPI, loginAsGuest } from './helpers';
+
+test.describe('Portfolio Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAPI(page);
+    await loginAsGuest(page);
+    await page.getByRole('link', { name: 'Portfolio' }).click();
+    await expect(page).toHaveURL('/portfolio');
+  });
+
+  test('displays portfolio summary cards', async ({ page }) => {
+    await expect(page.getByText('Net Worth')).toBeVisible();
+    await expect(page.getByText('$105,000.00')).toBeVisible();
+    await expect(page.getByText('Cash')).toBeVisible();
+    await expect(page.getByText('$85,000.00')).toBeVisible();
+  });
+
+  test('displays holdings with position data', async ({ page }) => {
+    await expect(page.getByText('PIPE')).toBeVisible();
+    await expect(page.getByText('$15,550.00')).toBeVisible();
+  });
+
+  test('switches between holdings and trade history tabs', async ({ page }) => {
+    await expect(page.getByText('Holdings')).toBeVisible();
+    await page.getByRole('button', { name: 'Trade History' }).click();
+    await expect(page.getByText('No trades yet.')).toBeVisible();
+  });
+});

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -1,0 +1,22 @@
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { FlatCompat } from '@eslint/eslintrc';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [
+  ...compat.extends('next/core-web-vitals', 'next/typescript'),
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+    },
+  },
+];
+
+export default eslintConfig;

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "type-check": "tsc --noEmit",
-    "test": "vitest",
+    "test": "vitest --passWithNoTests",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? 'github' : 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run build && npm run start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});

--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { TrendingUp } from 'lucide-react';
 import { apiClient } from '@/lib/api-client';
 import { useAuthStore } from '@/stores/auth-store';
 
@@ -23,6 +24,7 @@ export default function LoginPage() {
       setToken(guestUID);
       setUser(user);
       localStorage.setItem('mockstarket_token', guestUID);
+      document.cookie = `mockstarket_token=${guestUID}; path=/; max-age=${60 * 60 * 24 * 30}`;
       router.replace('/market');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Login failed');
@@ -36,7 +38,7 @@ export default function LoginPage() {
       <div className="w-full max-w-sm space-y-10">
         {/* Logo */}
         <div className="text-center space-y-4">
-          <div className="text-6xl">📈</div>
+          <TrendingUp className="w-16 h-16 text-[#50E3C2] mx-auto" />
           <h1 className="text-4xl font-bold tracking-tight text-white">
             Mock Starket
           </h1>

--- a/web/src/app/(dashboard)/achievements/page.tsx
+++ b/web/src/app/(dashboard)/achievements/page.tsx
@@ -1,14 +1,7 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { apiClient } from '@/lib/api-client';
-import type { Achievement } from '@/types/user';
-
-interface UserAchievement {
-  id: string;
-  achievement_id: string;
-  earned_at: string;
-}
+import { PageTransition } from '@/components/ui/PageTransition';
+import { useAchievements } from '@/hooks/use-achievements';
 
 const categoryLabels: Record<string, string> = {
   trading: 'Trading',
@@ -20,45 +13,28 @@ const categoryLabels: Record<string, string> = {
 };
 
 export default function AchievementsPage() {
-  const [achievements, setAchievements] = useState<Achievement[]>([]);
-  const [earned, setEarned] = useState<UserAchievement[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { data, isLoading } = useAchievements();
 
-  useEffect(() => {
-    async function load() {
-      setLoading(true);
-      try {
-        const [allAchievements, myAchievements] = await Promise.all([
-          apiClient.getAchievements(),
-          apiClient.getMyAchievements(),
-        ]);
-        setAchievements(allAchievements || []);
-        setEarned(myAchievements || []);
-      } catch (err) {
-        console.error('Failed to load achievements:', err);
-      } finally {
-        setLoading(false);
-      }
-    }
-    load();
-  }, []);
+  const achievements = data?.achievements || [];
+  const earned = data?.earned || [];
 
   const earnedIds = new Set(earned.map((e) => e.achievement_id));
   const earnedCount = earnedIds.size;
   const totalCount = achievements.length;
 
   // Group by category
-  const grouped = achievements.reduce<Record<string, Achievement[]>>((acc, a) => {
+  const grouped = achievements.reduce<Record<string, typeof achievements>>((acc, a) => {
     if (!acc[a.category]) acc[a.category] = [];
     acc[a.category].push(a);
     return acc;
   }, {});
 
-  if (loading) {
+  if (isLoading) {
     return <div className="p-6 text-center text-[#8B949E]">Loading achievements...</div>;
   }
 
   return (
+    <PageTransition>
     <div className="p-6 max-w-4xl mx-auto space-y-6">
       <div className="flex items-baseline justify-between">
         <h1 className="text-2xl font-bold">Achievements</h1>
@@ -100,7 +76,7 @@ export default function AchievementsPage() {
                     <div
                       className={`text-2xl flex-shrink-0 ${isEarned ? '' : 'grayscale'}`}
                     >
-                      {isEarned ? '&#x2714;' : '&#x1F512;'}
+                      {isEarned ? '\u2714' : '\uD83D\uDD12'}
                     </div>
                     <div className="min-w-0">
                       <h3 className={`font-semibold text-sm ${isEarned ? 'text-white' : 'text-[#8B949E]'}`}>
@@ -121,5 +97,6 @@ export default function AchievementsPage() {
         </div>
       ))}
     </div>
+    </PageTransition>
   );
 }

--- a/web/src/app/(dashboard)/alerts/page.tsx
+++ b/web/src/app/(dashboard)/alerts/page.tsx
@@ -1,78 +1,42 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { apiClient } from '@/lib/api-client';
+import { useState } from 'react';
+import { PageTransition } from '@/components/ui/PageTransition';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useAlerts, useCreateAlert, useDeleteAlert } from '@/hooks/use-alerts';
 import { formatCurrency } from '@/lib/formatters';
-
-interface PriceAlert {
-  id: string;
-  ticker: string;
-  condition: string;
-  target_price: string;
-  triggered: boolean;
-  triggered_at: string | null;
-  created_at: string;
-}
+import { alertSchema, type AlertFormValues } from '@/lib/schemas';
+import { FormInput } from '@/components/ui/FormInput';
 
 export default function AlertsPage() {
-  const [alerts, setAlerts] = useState<PriceAlert[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { data: alerts = [], isLoading } = useAlerts();
+  const createAlert = useCreateAlert();
+  const deleteAlert = useDeleteAlert();
 
-  // Create form
   const [showForm, setShowForm] = useState(false);
-  const [ticker, setTicker] = useState('');
-  const [condition, setCondition] = useState('above');
-  const [targetPrice, setTargetPrice] = useState('');
-  const [creating, setCreating] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const { register, handleSubmit, reset, formState: { errors } } = useForm<AlertFormValues>({
+    resolver: zodResolver(alertSchema),
+    defaultValues: { condition: 'above' },
+  });
 
-  useEffect(() => {
-    loadAlerts();
-  }, []);
-
-  async function loadAlerts() {
-    setLoading(true);
-    try {
-      const data = await apiClient.getAlerts();
-      setAlerts(data || []);
-    } catch (err) {
-      console.error('Failed to load alerts:', err);
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  async function handleCreate() {
-    if (!ticker || !targetPrice) return;
-    setCreating(true);
-    setError(null);
-
-    try {
-      await apiClient.createAlert(ticker.toUpperCase(), condition, targetPrice);
-      setShowForm(false);
-      setTicker('');
-      setTargetPrice('');
-      await loadAlerts();
-    } catch (err: any) {
-      setError(err.message || 'Failed to create alert');
-    } finally {
-      setCreating(false);
-    }
-  }
-
-  async function handleDelete(id: string) {
-    try {
-      await apiClient.deleteAlert(id);
-      setAlerts((prev) => prev.filter((a) => a.id !== id));
-    } catch (err) {
-      console.error('Failed to delete alert:', err);
-    }
+  function onSubmitAlert(data: AlertFormValues) {
+    createAlert.mutate(
+      { ticker: data.ticker, condition: data.condition, targetPrice: data.target_price },
+      {
+        onSuccess: () => {
+          setShowForm(false);
+          reset();
+        },
+      }
+    );
   }
 
   const activeAlerts = alerts.filter((a) => !a.triggered);
   const triggeredAlerts = alerts.filter((a) => a.triggered);
 
   return (
+    <PageTransition>
     <div className="p-6 max-w-4xl mx-auto space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">Price Alerts</h1>
@@ -86,58 +50,41 @@ export default function AlertsPage() {
 
       {/* Create Alert Form */}
       {showForm && (
-        <div className="rounded-xl bg-[#161B22] border border-[#30363D] p-6 space-y-4">
+        <form onSubmit={handleSubmit(onSubmitAlert)} className="rounded-xl bg-[#161B22] border border-[#30363D] p-6 space-y-4">
           <h2 className="font-semibold">Create Alert</h2>
 
           <div className="grid grid-cols-3 gap-4">
-            <div>
-              <label className="block text-xs text-[#6E7681] mb-1.5">Ticker</label>
-              <input
-                type="text"
-                value={ticker}
-                onChange={(e) => setTicker(e.target.value.toUpperCase())}
-                placeholder="PIPE"
-                className="w-full rounded-lg bg-[#0D1117] border border-[#30363D] px-4 py-2.5 text-white placeholder-[#6E7681] focus:outline-none focus:border-[#50E3C2] text-sm"
-              />
-            </div>
+            <FormInput label="Ticker" placeholder="PIPE" error={errors.ticker?.message} {...register('ticker')} />
             <div>
               <label className="block text-xs text-[#6E7681] mb-1.5">Condition</label>
               <select
-                value={condition}
-                onChange={(e) => setCondition(e.target.value)}
+                {...register('condition')}
                 className="w-full rounded-lg bg-[#0D1117] border border-[#30363D] px-4 py-2.5 text-white text-sm focus:outline-none focus:border-[#50E3C2]"
               >
                 <option value="above">Price goes above</option>
                 <option value="below">Price goes below</option>
               </select>
             </div>
-            <div>
-              <label className="block text-xs text-[#6E7681] mb-1.5">Target Price</label>
-              <input
-                type="text"
-                value={targetPrice}
-                onChange={(e) => setTargetPrice(e.target.value)}
-                placeholder="100.00"
-                className="w-full rounded-lg bg-[#0D1117] border border-[#30363D] px-4 py-2.5 text-white placeholder-[#6E7681] focus:outline-none focus:border-[#50E3C2] text-sm"
-              />
-            </div>
+            <FormInput label="Target Price" placeholder="100.00" error={errors.target_price?.message} {...register('target_price')} />
           </div>
 
-          {error && (
-            <div className="rounded-lg bg-red-500/10 text-red-400 px-4 py-2.5 text-sm">{error}</div>
+          {createAlert.isError && (
+            <div className="rounded-lg bg-red-500/10 text-red-400 px-4 py-2.5 text-sm">
+              {createAlert.error?.message || 'Failed to create alert'}
+            </div>
           )}
 
           <button
-            onClick={handleCreate}
-            disabled={creating || !ticker || !targetPrice}
+            type="submit"
+            disabled={createAlert.isPending}
             className="px-6 py-2.5 rounded-lg bg-[#50E3C2] text-[#0D1117] text-sm font-semibold hover:bg-[#3BC4A7] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
           >
-            {creating ? 'Creating...' : 'Create Alert'}
+            {createAlert.isPending ? 'Creating...' : 'Create Alert'}
           </button>
-        </div>
+        </form>
       )}
 
-      {loading ? (
+      {isLoading ? (
         <div className="p-8 text-center text-[#8B949E]">Loading alerts...</div>
       ) : alerts.length === 0 ? (
         <div className="rounded-xl bg-[#161B22] border border-[#30363D] p-8 text-center text-[#8B949E]">
@@ -157,12 +104,12 @@ export default function AlertsPage() {
                         {alert.ticker}
                       </span>
                       <span className="text-sm text-[#8B949E]">
-                        {alert.condition === 'above' ? '↑ Above' : '↓ Below'}{' '}
+                        {alert.condition === 'above' ? '\u2191 Above' : '\u2193 Below'}{' '}
                         <span className="text-white font-medium">{formatCurrency(alert.target_price)}</span>
                       </span>
                     </div>
                     <button
-                      onClick={() => handleDelete(alert.id)}
+                      onClick={() => deleteAlert.mutate(alert.id)}
                       className="text-xs text-red-400 hover:text-red-300 transition-colors"
                     >
                       Delete
@@ -185,13 +132,13 @@ export default function AlertsPage() {
                         {alert.ticker}
                       </span>
                       <span className="text-sm text-[#8B949E]">
-                        {alert.condition === 'above' ? '↑ Above' : '↓ Below'}{' '}
+                        {alert.condition === 'above' ? '\u2191 Above' : '\u2193 Below'}{' '}
                         <span className="text-white font-medium">{formatCurrency(alert.target_price)}</span>
                       </span>
                       <span className="text-xs text-emerald-400">Triggered</span>
                     </div>
                     <button
-                      onClick={() => handleDelete(alert.id)}
+                      onClick={() => deleteAlert.mutate(alert.id)}
                       className="text-xs text-[#6E7681] hover:text-red-400 transition-colors"
                     >
                       Remove
@@ -204,5 +151,6 @@ export default function AlertsPage() {
         </>
       )}
     </div>
+    </PageTransition>
   );
 }

--- a/web/src/app/(dashboard)/challenges/page.tsx
+++ b/web/src/app/(dashboard)/challenges/page.tsx
@@ -1,112 +1,48 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { apiClient } from '@/lib/api-client';
+import { PageTransition } from '@/components/ui/PageTransition';
+import { useTodaysChallenge, useCheckChallenge, useClaimChallenge } from '@/hooks/use-challenges';
 import { formatCurrency } from '@/lib/formatters';
 
-interface DailyChallenge {
-  id: string;
-  date: string;
-  challenge_type: string;
-  description: string;
-  reward_cash: string;
-}
-
-interface UserProgress {
-  completed: boolean;
-  completed_at: string | null;
-  claimed: boolean;
-}
-
 const challengeIcons: Record<string, string> = {
-  trade_count: '🔄',
-  buy_stock: '🛒',
-  sell_stock: '💰',
-  profit_target: '📈',
-  diversify: '🎯',
-  volume_trader: '📊',
+  trade_count: '\uD83D\uDD04',
+  buy_stock: '\uD83D\uDED2',
+  sell_stock: '\uD83D\uDCB0',
+  profit_target: '\uD83D\uDCC8',
+  diversify: '\uD83C\uDFAF',
+  volume_trader: '\uD83D\uDCCA',
 };
 
 export default function ChallengesPage() {
-  const [challenge, setChallenge] = useState<DailyChallenge | null>(null);
-  const [progress, setProgress] = useState<UserProgress | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [checking, setChecking] = useState(false);
-  const [claiming, setClaiming] = useState(false);
-  const [message, setMessage] = useState<string | null>(null);
+  const { data, isLoading } = useTodaysChallenge();
+  const checkChallenge = useCheckChallenge();
+  const claimChallenge = useClaimChallenge();
 
-  useEffect(() => {
-    loadChallenge();
-  }, []);
+  const challenge = data?.challenge;
+  const progress = data?.progress;
 
-  async function loadChallenge() {
-    setLoading(true);
-    try {
-      const data = await apiClient.getTodaysChallenge();
-      setChallenge(data.challenge);
-      setProgress(data.progress);
-    } catch {
-      setChallenge(null);
-      setProgress(null);
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  async function handleCheck() {
-    setChecking(true);
-    setMessage(null);
-    try {
-      const result = await apiClient.checkChallenge();
-      if (result.completed) {
-        setMessage('Challenge completed! Claim your reward below.');
-        await loadChallenge();
-      } else {
-        setMessage('Not yet complete. Keep trading!');
-      }
-    } catch {
-      setMessage('Failed to check progress.');
-    } finally {
-      setChecking(false);
-    }
-  }
-
-  async function handleClaim() {
-    if (!challenge) return;
-    setClaiming(true);
-    setMessage(null);
-    try {
-      await apiClient.claimChallenge(challenge.id);
-      setMessage('Reward claimed! Cash has been added to your portfolio.');
-      await loadChallenge();
-    } catch (err: any) {
-      setMessage(err.message || 'Failed to claim reward.');
-    } finally {
-      setClaiming(false);
-    }
-  }
-
-  if (loading) {
+  if (isLoading) {
     return <div className="p-6 text-center text-[#8B949E]">Loading challenge...</div>;
   }
 
   return (
+    <PageTransition>
     <div className="p-6 max-w-2xl mx-auto space-y-6">
       <h1 className="text-2xl font-bold">Daily Challenge</h1>
 
       {!challenge ? (
         <div className="rounded-xl bg-[#161B22] border border-[#30363D] p-8 text-center">
-          <p className="text-4xl mb-4">🎯</p>
+          <p className="text-4xl mb-4">{'\uD83C\uDFAF'}</p>
           <p className="text-[#8B949E]">No challenge available today. Check back later!</p>
         </div>
       ) : (
         <div className="rounded-xl bg-[#161B22] border border-[#30363D] p-8 space-y-6">
           {/* Challenge header */}
           <div className="text-center space-y-3">
-            <p className="text-5xl">{challengeIcons[challenge.challenge_type] || '🎯'}</p>
+            <p className="text-5xl">{challengeIcons[challenge.challenge_type] || '\uD83C\uDFAF'}</p>
             <h2 className="text-xl font-bold">{challenge.description}</h2>
             <div className="inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-4 py-2 text-sm font-medium text-emerald-400">
-              <span>💵</span>
+              <span>{'\uD83D\uDCB5'}</span>
               Reward: {formatCurrency(challenge.reward_cash)}
             </div>
           </div>
@@ -116,7 +52,7 @@ export default function ChallengesPage() {
             {progress?.claimed ? (
               <div className="text-center space-y-3">
                 <div className="inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-6 py-3 text-emerald-400 font-semibold">
-                  <span>✅</span> Reward Claimed!
+                  <span>{'\u2705'}</span> Reward Claimed!
                 </div>
                 <p className="text-sm text-[#8B949E]">
                   Come back tomorrow for a new challenge.
@@ -126,11 +62,11 @@ export default function ChallengesPage() {
               <div className="text-center space-y-4">
                 <p className="text-sm text-emerald-400 font-medium">Challenge completed!</p>
                 <button
-                  onClick={handleClaim}
-                  disabled={claiming}
+                  onClick={() => claimChallenge.mutate(challenge.id)}
+                  disabled={claimChallenge.isPending}
                   className="w-full py-3 rounded-lg bg-emerald-500 hover:bg-emerald-600 text-white text-sm font-semibold transition-colors disabled:opacity-50"
                 >
-                  {claiming ? 'Claiming...' : 'Claim Reward'}
+                  {claimChallenge.isPending ? 'Claiming...' : 'Claim Reward'}
                 </button>
               </div>
             ) : (
@@ -140,21 +76,18 @@ export default function ChallengesPage() {
                   In Progress
                 </div>
                 <button
-                  onClick={handleCheck}
-                  disabled={checking}
+                  onClick={() => checkChallenge.mutate()}
+                  disabled={checkChallenge.isPending}
                   className="w-full py-3 rounded-lg bg-[#21262D] hover:bg-[#30363D] text-white text-sm font-semibold transition-colors disabled:opacity-50"
                 >
-                  {checking ? 'Checking...' : 'Check Progress'}
+                  {checkChallenge.isPending ? 'Checking...' : 'Check Progress'}
                 </button>
               </div>
-            )}
-
-            {message && (
-              <p className="text-center text-sm mt-4 text-[#8B949E]">{message}</p>
             )}
           </div>
         </div>
       )}
     </div>
+    </PageTransition>
   );
 }

--- a/web/src/app/(dashboard)/layout.tsx
+++ b/web/src/app/(dashboard)/layout.tsx
@@ -3,22 +3,28 @@
 import { useEffect } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
+import { BarChart3, Briefcase, ClipboardList, Trophy, Star, Bell, Target, Award, Settings } from 'lucide-react';
 import { apiClient } from '@/lib/api-client';
 import { wsClient } from '@/lib/websocket-client';
+import { toast } from '@/lib/toast';
 import { useAuthStore } from '@/stores/auth-store';
 import { useMarketStore } from '@/stores/market-store';
+import { ConnectionStatus } from '@/components/ui/ConnectionStatus';
+import { formatCurrency } from '@/lib/formatters';
 
 const navItems = [
-  { href: '/market', label: 'Market', icon: '📊' },
-  { href: '/portfolio', label: 'Portfolio', icon: '💼' },
-  { href: '/orders', label: 'Orders', icon: '📋' },
-  { href: '/leaderboard', label: 'Leaderboard', icon: '🏆' },
+  { href: '/market', label: 'Market', icon: BarChart3 },
+  { href: '/portfolio', label: 'Portfolio', icon: Briefcase },
+  { href: '/orders', label: 'Orders', icon: ClipboardList },
+  { href: '/leaderboard', label: 'Leaderboard', icon: Trophy },
 ];
 
 const sidebarExtras = [
-  { href: '/alerts', label: 'Alerts', icon: '🔔' },
-  { href: '/challenges', label: 'Challenges', icon: '🎯' },
-  { href: '/achievements', label: 'Achievements', icon: '⭐' },
+  { href: '/watchlist', label: 'Watchlist', icon: Star },
+  { href: '/alerts', label: 'Alerts', icon: Bell },
+  { href: '/challenges', label: 'Challenges', icon: Target },
+  { href: '/achievements', label: 'Achievements', icon: Award },
 ];
 
 export default function DashboardLayout({
@@ -29,6 +35,7 @@ export default function DashboardLayout({
   const pathname = usePathname();
   const { token } = useAuthStore();
   const { updatePrices } = useMarketStore();
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     // Restore token from localStorage
@@ -36,6 +43,8 @@ export default function DashboardLayout({
     if (savedToken) {
       apiClient.setToken(savedToken);
       useAuthStore.getState().setToken(savedToken);
+      // Ensure cookie is set for middleware
+      document.cookie = `mockstarket_token=${savedToken}; path=/; max-age=${60 * 60 * 24 * 30}`;
     }
   }, []);
 
@@ -43,12 +52,48 @@ export default function DashboardLayout({
     if (!token) return;
 
     wsClient.connect(token);
+
+    // Price updates
     wsClient.on('price_batch', (data) => {
       updatePrices(data);
     });
 
+    // Trade executed
+    wsClient.on('trade_executed', (data) => {
+      const action = data.side === 'buy' ? 'Bought' : 'Sold';
+      toast.info(`${action} ${data.shares} shares of ${data.ticker} at ${formatCurrency(data.price)}`);
+      queryClient.invalidateQueries({ queryKey: ['portfolio'] });
+      queryClient.invalidateQueries({ queryKey: ['trades'] });
+    });
+
+    // Order matched/filled
+    wsClient.on('order_matched', (data) => {
+      toast.success(`Order filled: ${data.shares} shares of ${data.ticker} at ${formatCurrency(data.price)}`);
+      queryClient.invalidateQueries({ queryKey: ['orders'] });
+      queryClient.invalidateQueries({ queryKey: ['portfolio'] });
+      queryClient.invalidateQueries({ queryKey: ['trades'] });
+    });
+
+    // Alert triggered
+    wsClient.on('alert_triggered', (data) => {
+      toast.info(`Price alert: ${data.ticker} ${data.condition} ${formatCurrency(data.target_price)}`);
+      queryClient.invalidateQueries({ queryKey: ['alerts'] });
+    });
+
+    // Achievement earned
+    wsClient.on('achievement_earned', (data) => {
+      toast.success(`Achievement unlocked: ${data.name || 'New achievement!'}`);
+      queryClient.invalidateQueries({ queryKey: ['achievements'] });
+    });
+
+    // Challenge completed
+    wsClient.on('challenge_completed', () => {
+      toast.success('Daily challenge completed! Claim your reward.');
+      queryClient.invalidateQueries({ queryKey: ['challenge'] });
+    });
+
     return () => wsClient.disconnect();
-  }, [token, updatePrices]);
+  }, [token, updatePrices, queryClient]);
 
   return (
     <div className="flex h-screen bg-[#0D1117]">
@@ -60,46 +105,56 @@ export default function DashboardLayout({
         </div>
 
         <nav className="flex-1 px-3 space-y-1">
-          {navItems.map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              className={`flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors ${
-                pathname === item.href
-                  ? 'bg-[#21262D] text-white'
-                  : 'text-[#8B949E] hover:bg-[#21262D] hover:text-white'
-              }`}
-            >
-              <span>{item.icon}</span>
-              {item.label}
-            </Link>
-          ))}
+          {navItems.map((item) => {
+            const Icon = item.icon;
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors ${
+                  pathname === item.href
+                    ? 'bg-[#21262D] text-white'
+                    : 'text-[#8B949E] hover:bg-[#21262D] hover:text-white'
+                }`}
+              >
+                <Icon className="w-4 h-4" />
+                {item.label}
+              </Link>
+            );
+          })}
         </nav>
 
         <div className="px-3 pt-4 border-t border-[#30363D] space-y-1">
-          {sidebarExtras.map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
-                pathname === item.href
-                  ? 'bg-[#21262D] text-white'
-                  : 'text-[#8B949E] hover:bg-[#21262D] hover:text-white'
-              }`}
-            >
-              <span>{item.icon}</span>
-              {item.label}
-            </Link>
-          ))}
+          {sidebarExtras.map((item) => {
+            const Icon = item.icon;
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+                  pathname === item.href
+                    ? 'bg-[#21262D] text-white'
+                    : 'text-[#8B949E] hover:bg-[#21262D] hover:text-white'
+                }`}
+              >
+                <Icon className="w-4 h-4" />
+                {item.label}
+              </Link>
+            );
+          })}
         </div>
 
-        <div className="p-4 border-t border-[#30363D]">
+        <div className="p-4 border-t border-[#30363D] space-y-3">
           <Link
             href="/settings"
             className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm text-[#8B949E] hover:text-white transition-colors"
           >
-            ⚙️ Settings
+            <Settings className="w-4 h-4" />
+            Settings
           </Link>
+          <div className="px-3">
+            <ConnectionStatus />
+          </div>
         </div>
       </aside>
 
@@ -110,18 +165,21 @@ export default function DashboardLayout({
 
       {/* Mobile bottom nav */}
       <nav className="md:hidden fixed bottom-0 left-0 right-0 flex border-t border-[#30363D] bg-[#161B22]">
-        {navItems.map((item) => (
-          <Link
-            key={item.href}
-            href={item.href}
-            className={`flex-1 flex flex-col items-center py-2 text-xs ${
-              pathname === item.href ? 'text-[#50E3C2]' : 'text-[#6E7681]'
-            }`}
-          >
-            <span className="text-lg">{item.icon}</span>
-            {item.label}
-          </Link>
-        ))}
+        {navItems.map((item) => {
+          const Icon = item.icon;
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`flex-1 flex flex-col items-center py-2 text-xs ${
+                pathname === item.href ? 'text-[#50E3C2]' : 'text-[#6E7681]'
+              }`}
+            >
+              <Icon className="w-5 h-5 mb-0.5" />
+              {item.label}
+            </Link>
+          );
+        })}
       </nav>
     </div>
   );

--- a/web/src/app/(dashboard)/leaderboard/page.tsx
+++ b/web/src/app/(dashboard)/leaderboard/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { apiClient } from '@/lib/api-client';
+import { useState } from 'react';
+import { PageTransition } from '@/components/ui/PageTransition';
+import { TableSkeleton } from '@/components/ui/TableSkeleton';
+import { useLeaderboard } from '@/hooks/use-leaderboard';
 import { formatCurrency, formatPercent, priceChangeColor } from '@/lib/formatters';
-import type { LeaderboardEntry } from '@/types/user';
 
 const periods = [
   { value: 'alltime', label: 'All Time' },
@@ -12,26 +13,11 @@ const periods = [
 ];
 
 export default function LeaderboardPage() {
-  const [entries, setEntries] = useState<LeaderboardEntry[]>([]);
   const [period, setPeriod] = useState('alltime');
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    async function load() {
-      setLoading(true);
-      try {
-        const data = await apiClient.getLeaderboard(period);
-        setEntries(data || []);
-      } catch (err) {
-        console.error('Failed to load leaderboard:', err);
-      } finally {
-        setLoading(false);
-      }
-    }
-    load();
-  }, [period]);
+  const { data: entries = [], isLoading } = useLeaderboard(period);
 
   return (
+    <PageTransition>
     <div className="p-6 max-w-4xl mx-auto space-y-6">
       <h1 className="text-2xl font-bold">Leaderboard</h1>
 
@@ -54,8 +40,8 @@ export default function LeaderboardPage() {
 
       {/* Leaderboard Table */}
       <div className="rounded-xl bg-[#161B22] border border-[#30363D] overflow-hidden">
-        {loading ? (
-          <div className="p-8 text-center text-[#8B949E]">Loading rankings...</div>
+        {isLoading ? (
+          <TableSkeleton rows={6} columns={4} />
         ) : entries.length === 0 ? (
           <div className="p-8 text-center text-[#8B949E]">
             No rankings yet. Start trading to appear on the leaderboard!
@@ -109,5 +95,6 @@ export default function LeaderboardPage() {
         )}
       </div>
     </div>
+    </PageTransition>
   );
 }

--- a/web/src/app/(dashboard)/market/page.tsx
+++ b/web/src/app/(dashboard)/market/page.tsx
@@ -1,14 +1,23 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import Link from 'next/link';
 import { apiClient } from '@/lib/api-client';
 import { useMarketStore } from '@/stores/market-store';
 import { formatCurrency, formatPercent, priceChangeColor, priceChangeBg } from '@/lib/formatters';
 import type { Stock, MarketSummary } from '@/types/stock';
 
+const assetFilters = [
+  { value: 'all', label: 'All' },
+  { value: 'stock', label: 'Stocks' },
+  { value: 'etf', label: 'ETFs' },
+  { value: 'crypto', label: 'Crypto' },
+  { value: 'commodity', label: 'Commodities' },
+];
+
 export default function MarketPage() {
   const { stocks, summary, isLoading, searchQuery, setStocks, setSummary, setLoading, setSearchQuery, filteredStocks } = useMarketStore();
+  const [assetFilter, setAssetFilter] = useState('all');
 
   useEffect(() => {
     async function loadData() {
@@ -29,7 +38,11 @@ export default function MarketPage() {
     loadData();
   }, [setStocks, setSummary, setLoading]);
 
-  const displayed = filteredStocks();
+  const displayed = useMemo(() => {
+    const searched = filteredStocks();
+    if (assetFilter === 'all') return searched;
+    return searched.filter((s: Stock) => s.asset_type === assetFilter);
+  }, [filteredStocks, assetFilter]);
 
   return (
     <div className="p-6 max-w-6xl mx-auto space-y-6">
@@ -64,13 +77,30 @@ export default function MarketPage() {
         className="w-full rounded-lg bg-[#161B22] border border-[#30363D] px-4 py-3 text-sm text-white placeholder-[#6E7681] focus:outline-none focus:border-[#50E3C2]"
       />
 
+      {/* Asset Type Filter */}
+      <div className="flex gap-1 overflow-x-auto">
+        {assetFilters.map((f) => (
+          <button
+            key={f.value}
+            onClick={() => setAssetFilter(f.value)}
+            className={`px-4 py-2 rounded-lg text-sm font-medium whitespace-nowrap transition-colors ${
+              assetFilter === f.value
+                ? 'bg-[#21262D] text-white'
+                : 'text-[#8B949E] hover:text-white'
+            }`}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
       {/* Stock Table */}
       <div className="rounded-xl bg-[#161B22] border border-[#30363D] overflow-hidden">
         <table className="w-full">
           <thead>
             <tr className="border-b border-[#30363D] text-xs text-[#8B949E] uppercase">
               <th className="text-left px-4 py-3">Stock</th>
-              <th className="text-left px-4 py-3 hidden sm:table-cell">Sector</th>
+              <th className="text-left px-4 py-3 hidden sm:table-cell">Type</th>
               <th className="text-right px-4 py-3">Price</th>
               <th className="text-right px-4 py-3">Change</th>
             </tr>
@@ -93,8 +123,15 @@ export default function MarketPage() {
                       <span className="text-sm font-medium text-white">{stock.name}</span>
                     </Link>
                   </td>
-                  <td className="px-4 py-3 text-sm text-[#8B949E] hidden sm:table-cell">
-                    {stock.sector}
+                  <td className="px-4 py-3 hidden sm:table-cell">
+                    <span className={`text-xs font-medium px-2 py-0.5 rounded ${
+                      stock.asset_type === 'crypto' ? 'bg-orange-400/10 text-orange-400' :
+                      stock.asset_type === 'commodity' ? 'bg-yellow-400/10 text-yellow-400' :
+                      stock.asset_type === 'etf' ? 'bg-purple-400/10 text-purple-400' :
+                      'bg-[#8B949E]/10 text-[#8B949E]'
+                    }`}>
+                      {stock.asset_type?.toUpperCase() || 'STOCK'}
+                    </span>
                   </td>
                   <td className="px-4 py-3 text-right text-sm font-semibold text-white">
                     {formatCurrency(stock.current_price)}

--- a/web/src/app/(dashboard)/market/page.tsx
+++ b/web/src/app/(dashboard)/market/page.tsx
@@ -20,7 +20,9 @@ const assetFilters = [
 ];
 
 export default function MarketPage() {
-  const { setSearchQuery, filteredStocks } = useMarketStore();
+  const stocks = useMarketStore((s) => s.stocks);
+  const searchQuery = useMarketStore((s) => s.searchQuery);
+  const setSearchQuery = useMarketStore((s) => s.setSearchQuery);
   const [localSearch, setLocalSearch] = useState('');
   const [assetFilter, setAssetFilter] = useState('all');
   const debouncedSearch = useDebounce(localSearch, 300);
@@ -34,10 +36,16 @@ export default function MarketPage() {
   }, [debouncedSearch, setSearchQuery]);
 
   const filtered = useMemo(() => {
-    const searched = filteredStocks();
-    if (assetFilter === 'all') return searched;
-    return searched.filter((s: Stock) => s.asset_type === assetFilter);
-  }, [filteredStocks, assetFilter]);
+    let result = stocks;
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase();
+      result = result.filter((s) => s.ticker.toLowerCase().includes(q) || s.name.toLowerCase().includes(q));
+    }
+    if (assetFilter !== 'all') {
+      result = result.filter((s: Stock) => s.asset_type === assetFilter);
+    }
+    return result;
+  }, [stocks, searchQuery, assetFilter]);
 
   const { sorted: displayed, sortKey, sortDirection, onSort } = useSort(filtered, 'ticker', 'asc');
 

--- a/web/src/app/(dashboard)/market/page.tsx
+++ b/web/src/app/(dashboard)/market/page.tsx
@@ -1,11 +1,16 @@
 'use client';
 
-import { useEffect, useState, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import Link from 'next/link';
-import { apiClient } from '@/lib/api-client';
+import { useStocks, useMarketSummary } from '@/hooks/use-stocks';
 import { useMarketStore } from '@/stores/market-store';
+import { useDebounce } from '@/hooks/use-debounce';
+import { useSort } from '@/hooks/use-sort';
+import { PageTransition } from '@/components/ui/PageTransition';
+import { TableSkeleton } from '@/components/ui/TableSkeleton';
+import { CardSkeleton } from '@/components/ui/CardSkeleton';
 import { formatCurrency, formatPercent, priceChangeColor, priceChangeBg } from '@/lib/formatters';
-import type { Stock, MarketSummary } from '@/types/stock';
+import type { Stock } from '@/types/stock';
 
 const assetFilters = [
   { value: 'all', label: 'All' },
@@ -16,35 +21,29 @@ const assetFilters = [
 ];
 
 export default function MarketPage() {
-  const { stocks, summary, isLoading, searchQuery, setStocks, setSummary, setLoading, setSearchQuery, filteredStocks } = useMarketStore();
+  const { setSearchQuery, filteredStocks } = useMarketStore();
+  const [localSearch, setLocalSearch] = useState('');
   const [assetFilter, setAssetFilter] = useState('all');
+  const debouncedSearch = useDebounce(localSearch, 300);
 
-  useEffect(() => {
-    async function loadData() {
-      setLoading(true);
-      try {
-        const [stocksData, summaryData] = await Promise.all([
-          apiClient.getStocks(),
-          apiClient.getMarketSummary(),
-        ]);
-        setStocks(stocksData);
-        setSummary(summaryData);
-      } catch (err) {
-        console.error('Failed to load market data:', err);
-      } finally {
-        setLoading(false);
-      }
-    }
-    loadData();
-  }, [setStocks, setSummary, setLoading]);
+  const { isLoading: stocksLoading } = useStocks();
+  const { data: summary } = useMarketSummary();
 
-  const displayed = useMemo(() => {
+  // Sync debounced value to store
+  useMemo(() => {
+    setSearchQuery(debouncedSearch);
+  }, [debouncedSearch, setSearchQuery]);
+
+  const filtered = useMemo(() => {
     const searched = filteredStocks();
     if (assetFilter === 'all') return searched;
     return searched.filter((s: Stock) => s.asset_type === assetFilter);
   }, [filteredStocks, assetFilter]);
 
+  const { sorted: displayed, sortKey, sortDirection, onSort } = useSort(filtered, 'ticker', 'asc');
+
   return (
+    <PageTransition>
     <div className="p-6 max-w-6xl mx-auto space-y-6">
       <h1 className="text-2xl font-bold">Market</h1>
 
@@ -72,8 +71,8 @@ export default function MarketPage() {
       <input
         type="text"
         placeholder="Search stocks..."
-        value={searchQuery}
-        onChange={(e) => setSearchQuery(e.target.value)}
+        value={localSearch}
+        onChange={(e) => setLocalSearch(e.target.value)}
         className="w-full rounded-lg bg-[#161B22] border border-[#30363D] px-4 py-3 text-sm text-white placeholder-[#6E7681] focus:outline-none focus:border-[#50E3C2]"
       />
 
@@ -99,10 +98,16 @@ export default function MarketPage() {
         <table className="w-full">
           <thead>
             <tr className="border-b border-[#30363D] text-xs text-[#8B949E] uppercase">
-              <th className="text-left px-4 py-3">Stock</th>
+              <th className="text-left px-4 py-3 cursor-pointer hover:text-white select-none" onClick={() => onSort('ticker')}>
+                Stock {sortKey === 'ticker' && (sortDirection === 'asc' ? '↑' : '↓')}
+              </th>
               <th className="text-left px-4 py-3 hidden sm:table-cell">Type</th>
-              <th className="text-right px-4 py-3">Price</th>
-              <th className="text-right px-4 py-3">Change</th>
+              <th className="text-right px-4 py-3 cursor-pointer hover:text-white select-none" onClick={() => onSort('current_price')}>
+                Price {sortKey === 'current_price' && (sortDirection === 'asc' ? '↑' : '↓')}
+              </th>
+              <th className="text-right px-4 py-3 cursor-pointer hover:text-white select-none" onClick={() => onSort('name')}>
+                Change {sortKey === 'name' && (sortDirection === 'asc' ? '↑' : '↓')}
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -147,10 +152,9 @@ export default function MarketPage() {
           </tbody>
         </table>
 
-        {isLoading && (
-          <div className="p-8 text-center text-[#8B949E]">Loading stocks...</div>
-        )}
+        {stocksLoading && <TableSkeleton rows={8} columns={4} />}
       </div>
     </div>
+    </PageTransition>
   );
 }

--- a/web/src/app/(dashboard)/market/page.tsx
+++ b/web/src/app/(dashboard)/market/page.tsx
@@ -8,7 +8,6 @@ import { useDebounce } from '@/hooks/use-debounce';
 import { useSort } from '@/hooks/use-sort';
 import { PageTransition } from '@/components/ui/PageTransition';
 import { TableSkeleton } from '@/components/ui/TableSkeleton';
-import { CardSkeleton } from '@/components/ui/CardSkeleton';
 import { formatCurrency, formatPercent, priceChangeColor, priceChangeBg } from '@/lib/formatters';
 import type { Stock } from '@/types/stock';
 

--- a/web/src/app/(dashboard)/orders/page.tsx
+++ b/web/src/app/(dashboard)/orders/page.tsx
@@ -1,75 +1,44 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { apiClient } from '@/lib/api-client';
+import { useState } from 'react';
+import { PageTransition } from '@/components/ui/PageTransition';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useOrders, useCreateOrder, useCancelOrder } from '@/hooks/use-orders';
 import { formatCurrency } from '@/lib/formatters';
-import type { Order } from '@/types/portfolio';
+import { orderSchema, type OrderFormValues } from '@/lib/schemas';
+import { FormInput } from '@/components/ui/FormInput';
 
 export default function OrdersPage() {
-  const [orders, setOrders] = useState<Order[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { data: orders = [], isLoading } = useOrders();
+  const createOrder = useCreateOrder();
+  const cancelOrder = useCancelOrder();
 
-  // Create order form
   const [showForm, setShowForm] = useState(false);
-  const [ticker, setTicker] = useState('');
-  const [side, setSide] = useState('buy');
-  const [orderType, setOrderType] = useState('limit');
-  const [shares, setShares] = useState('');
-  const [limitPrice, setLimitPrice] = useState('');
-  const [stopPrice, setStopPrice] = useState('');
-  const [creating, setCreating] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const { register, handleSubmit, watch, reset, formState: { errors } } = useForm<OrderFormValues>({
+    resolver: zodResolver(orderSchema),
+    defaultValues: { side: 'buy', order_type: 'limit' },
+  });
+  const orderType = watch('order_type');
+  const side = watch('side');
 
-  useEffect(() => {
-    loadOrders();
-  }, []);
-
-  async function loadOrders() {
-    setLoading(true);
-    try {
-      const data = await apiClient.getOrders();
-      setOrders(data || []);
-    } catch (err) {
-      console.error('Failed to load orders:', err);
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  async function handleCreate() {
-    if (!ticker || !shares || parseInt(shares) <= 0) return;
-    setCreating(true);
-    setError(null);
-
-    try {
-      await apiClient.createOrder(
-        ticker.toUpperCase(),
-        side,
-        orderType,
-        parseInt(shares),
-        orderType !== 'stop' ? limitPrice || undefined : undefined,
-        orderType !== 'limit' ? stopPrice || undefined : undefined,
-      );
-      setShowForm(false);
-      setTicker('');
-      setShares('');
-      setLimitPrice('');
-      setStopPrice('');
-      await loadOrders();
-    } catch (err: any) {
-      setError(err.message || 'Failed to create order');
-    } finally {
-      setCreating(false);
-    }
-  }
-
-  async function handleCancel(id: string) {
-    try {
-      await apiClient.cancelOrder(id);
-      setOrders((prev) => prev.filter((o) => o.id !== id));
-    } catch (err) {
-      console.error('Failed to cancel order:', err);
-    }
+  function onSubmitOrder(data: OrderFormValues) {
+    createOrder.mutate(
+      {
+        ticker: data.ticker,
+        side: data.side,
+        orderType: data.order_type,
+        shares: data.shares,
+        limitPrice: data.limit_price || undefined,
+        stopPrice: data.stop_price || undefined,
+      },
+      {
+        onSuccess: () => {
+          setShowForm(false);
+          reset();
+        },
+      }
+    );
   }
 
   const orderTypeLabel: Record<string, string> = {
@@ -79,6 +48,7 @@ export default function OrdersPage() {
   };
 
   return (
+    <PageTransition>
     <div className="p-6 max-w-4xl mx-auto space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">Orders</h1>
@@ -92,56 +62,32 @@ export default function OrdersPage() {
 
       {/* Create Order Form */}
       {showForm && (
-        <div className="rounded-xl bg-[#161B22] border border-[#30363D] p-6 space-y-4">
+        <form onSubmit={handleSubmit(onSubmitOrder)} className="rounded-xl bg-[#161B22] border border-[#30363D] p-6 space-y-4">
           <h2 className="font-semibold">Create Order</h2>
 
           <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label className="block text-xs text-[#6E7681] mb-1.5">Ticker</label>
-              <input
-                type="text"
-                value={ticker}
-                onChange={(e) => setTicker(e.target.value.toUpperCase())}
-                placeholder="PIPE"
-                className="w-full rounded-lg bg-[#0D1117] border border-[#30363D] px-4 py-2.5 text-white placeholder-[#6E7681] focus:outline-none focus:border-[#50E3C2] text-sm"
-              />
-            </div>
-            <div>
-              <label className="block text-xs text-[#6E7681] mb-1.5">Shares</label>
-              <input
-                type="number"
-                min="1"
-                value={shares}
-                onChange={(e) => setShares(e.target.value)}
-                placeholder="10"
-                className="w-full rounded-lg bg-[#0D1117] border border-[#30363D] px-4 py-2.5 text-white placeholder-[#6E7681] focus:outline-none focus:border-[#50E3C2] text-sm"
-              />
-            </div>
+            <FormInput label="Ticker" placeholder="PIPE" error={errors.ticker?.message} {...register('ticker')} />
+            <FormInput label="Shares" type="number" min="1" placeholder="10" error={errors.shares?.message} {...register('shares')} />
           </div>
 
           <div className="grid grid-cols-2 gap-4">
             <div>
               <label className="block text-xs text-[#6E7681] mb-1.5">Side</label>
               <div className="flex rounded-lg overflow-hidden border border-[#30363D]">
-                <button
-                  onClick={() => setSide('buy')}
-                  className={`flex-1 py-2 text-sm font-semibold ${side === 'buy' ? 'bg-emerald-500/20 text-emerald-400' : 'text-[#8B949E]'}`}
-                >
+                <label className={`flex-1 py-2 text-sm font-semibold text-center cursor-pointer ${side === 'buy' ? 'bg-emerald-500/20 text-emerald-400' : 'text-[#8B949E]'}`}>
+                  <input type="radio" value="buy" className="sr-only" {...register('side')} />
                   Buy
-                </button>
-                <button
-                  onClick={() => setSide('sell')}
-                  className={`flex-1 py-2 text-sm font-semibold ${side === 'sell' ? 'bg-red-500/20 text-red-400' : 'text-[#8B949E]'}`}
-                >
+                </label>
+                <label className={`flex-1 py-2 text-sm font-semibold text-center cursor-pointer ${side === 'sell' ? 'bg-red-500/20 text-red-400' : 'text-[#8B949E]'}`}>
+                  <input type="radio" value="sell" className="sr-only" {...register('side')} />
                   Sell
-                </button>
+                </label>
               </div>
             </div>
             <div>
               <label className="block text-xs text-[#6E7681] mb-1.5">Order Type</label>
               <select
-                value={orderType}
-                onChange={(e) => setOrderType(e.target.value)}
+                {...register('order_type')}
                 className="w-full rounded-lg bg-[#0D1117] border border-[#30363D] px-4 py-2.5 text-white text-sm focus:outline-none focus:border-[#50E3C2]"
               >
                 <option value="limit">Limit</option>
@@ -153,48 +99,32 @@ export default function OrdersPage() {
 
           <div className="grid grid-cols-2 gap-4">
             {orderType !== 'stop' && (
-              <div>
-                <label className="block text-xs text-[#6E7681] mb-1.5">Limit Price</label>
-                <input
-                  type="text"
-                  value={limitPrice}
-                  onChange={(e) => setLimitPrice(e.target.value)}
-                  placeholder="100.00"
-                  className="w-full rounded-lg bg-[#0D1117] border border-[#30363D] px-4 py-2.5 text-white placeholder-[#6E7681] focus:outline-none focus:border-[#50E3C2] text-sm"
-                />
-              </div>
+              <FormInput label="Limit Price" placeholder="100.00" error={errors.limit_price?.message} {...register('limit_price')} />
             )}
             {orderType !== 'limit' && (
-              <div>
-                <label className="block text-xs text-[#6E7681] mb-1.5">Stop Price</label>
-                <input
-                  type="text"
-                  value={stopPrice}
-                  onChange={(e) => setStopPrice(e.target.value)}
-                  placeholder="95.00"
-                  className="w-full rounded-lg bg-[#0D1117] border border-[#30363D] px-4 py-2.5 text-white placeholder-[#6E7681] focus:outline-none focus:border-[#50E3C2] text-sm"
-                />
-              </div>
+              <FormInput label="Stop Price" placeholder="95.00" error={errors.stop_price?.message} {...register('stop_price')} />
             )}
           </div>
 
-          {error && (
-            <div className="rounded-lg bg-red-500/10 text-red-400 px-4 py-2.5 text-sm">{error}</div>
+          {createOrder.isError && (
+            <div className="rounded-lg bg-red-500/10 text-red-400 px-4 py-2.5 text-sm">
+              {createOrder.error?.message || 'Failed to create order'}
+            </div>
           )}
 
           <button
-            onClick={handleCreate}
-            disabled={creating || !ticker || !shares}
+            type="submit"
+            disabled={createOrder.isPending}
             className="w-full py-3 rounded-lg bg-[#50E3C2] text-[#0D1117] text-sm font-semibold hover:bg-[#3BC4A7] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
           >
-            {creating ? 'Creating...' : 'Place Order'}
+            {createOrder.isPending ? 'Creating...' : 'Place Order'}
           </button>
-        </div>
+        </form>
       )}
 
       {/* Orders List */}
       <div className="rounded-xl bg-[#161B22] border border-[#30363D] overflow-hidden">
-        {loading ? (
+        {isLoading ? (
           <div className="p-8 text-center text-[#8B949E]">Loading orders...</div>
         ) : orders.length === 0 ? (
           <div className="p-8 text-center text-[#8B949E]">
@@ -238,7 +168,7 @@ export default function OrdersPage() {
                   </td>
                   <td className="px-4 py-3 text-right">
                     <button
-                      onClick={() => handleCancel(order.id)}
+                      onClick={() => cancelOrder.mutate(order.id)}
                       className="text-xs text-red-400 hover:text-red-300 transition-colors"
                     >
                       Cancel
@@ -251,5 +181,6 @@ export default function OrdersPage() {
         )}
       </div>
     </div>
+    </PageTransition>
   );
 }

--- a/web/src/app/(dashboard)/portfolio/page.tsx
+++ b/web/src/app/(dashboard)/portfolio/page.tsx
@@ -1,56 +1,30 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import Link from 'next/link';
-import { apiClient } from '@/lib/api-client';
-import { formatCurrency, formatPercent, priceChangeColor, priceChangeBg } from '@/lib/formatters';
-import type { Trade } from '@/types/portfolio';
+import dynamic from 'next/dynamic';
+import { usePortfolio, usePortfolioHistory, useTradeHistory } from '@/hooks/use-portfolio';
+import { PageTransition } from '@/components/ui/PageTransition';
+import { CardSkeleton } from '@/components/ui/CardSkeleton';
+import { formatCurrency, formatPercent, priceChangeColor } from '@/lib/formatters';
 
-interface Position {
-  id: string;
-  ticker: string;
-  shares: number;
-  avg_cost: string;
-  current_price: string;
-  market_value: string;
-  pnl: string;
-  pnl_pct: string;
-}
-
-interface PortfolioData {
-  portfolio: { id: string; cash: string; net_worth: string };
-  positions: Position[];
-  net_worth: string;
-  invested: string;
-}
+const PortfolioChart = dynamic(() => import('@/components/charts/PortfolioChart'), { ssr: false });
 
 export default function PortfolioPage() {
-  const [data, setData] = useState<PortfolioData | null>(null);
-  const [trades, setTrades] = useState<Trade[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { data, isLoading } = usePortfolio();
+  const { data: trades = [] } = useTradeHistory(20, 0);
+  const { data: portfolioHistory = [] } = usePortfolioHistory(100);
   const [tab, setTab] = useState<'holdings' | 'history'>('holdings');
 
-  useEffect(() => {
-    async function load() {
-      setLoading(true);
-      try {
-        const [portfolio, tradeHistory] = await Promise.all([
-          apiClient.getPortfolio(),
-          apiClient.getTradeHistory(20, 0),
-        ]);
-        setData(portfolio);
-        setTrades(tradeHistory || []);
-      } catch (err) {
-        console.error('Failed to load portfolio:', err);
-      } finally {
-        setLoading(false);
-      }
-    }
-    load();
-  }, []);
-
-  if (loading) {
-    return <div className="p-6 text-center text-[#8B949E]">Loading portfolio...</div>;
+  if (isLoading) {
+    return (
+      <div className="p-6 max-w-6xl mx-auto space-y-6">
+        <h1 className="text-2xl font-bold">Portfolio</h1>
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+          <CardSkeleton /><CardSkeleton /><CardSkeleton /><CardSkeleton />
+        </div>
+      </div>
+    );
   }
 
   if (!data) {
@@ -60,10 +34,11 @@ export default function PortfolioPage() {
   const netWorth = parseFloat(data.net_worth);
   const cash = parseFloat(data.portfolio.cash);
   const invested = parseFloat(data.invested);
-  const totalPnl = netWorth - 100000; // starting cash
+  const totalPnl = netWorth - 100000;
   const totalPnlPct = (totalPnl / 100000) * 100;
 
   return (
+    <PageTransition>
     <div className="p-6 max-w-6xl mx-auto space-y-6">
       <h1 className="text-2xl font-bold">Portfolio</h1>
 
@@ -100,6 +75,19 @@ export default function PortfolioPage() {
           </p>
         </div>
       </div>
+
+      {/* Portfolio Performance Chart */}
+      {portfolioHistory.length > 1 && (
+        <div className="rounded-xl bg-[#161B22] border border-[#30363D] p-6">
+          <h2 className="font-semibold mb-4">Performance</h2>
+          <PortfolioChart
+            data={portfolioHistory.map((h: any) => ({
+              time: h.recorded_at,
+              value: parseFloat(h.net_worth),
+            }))}
+          />
+        </div>
+      )}
 
       {/* Tab Toggle */}
       <div className="flex border-b border-[#30363D]">
@@ -153,10 +141,7 @@ export default function PortfolioPage() {
                     className="border-b border-[#21262D] hover:bg-[#21262D] transition-colors"
                   >
                     <td className="px-4 py-3">
-                      <Link
-                        href={`/stock/${pos.ticker}`}
-                        className="flex items-center gap-2"
-                      >
+                      <Link href={`/stock/${pos.ticker}`} className="flex items-center gap-2">
                         <span className="rounded bg-[#50E3C2]/10 px-2 py-0.5 text-xs font-mono font-bold text-[#50E3C2]">
                           {pos.ticker}
                         </span>
@@ -234,5 +219,6 @@ export default function PortfolioPage() {
         </div>
       )}
     </div>
+    </PageTransition>
   );
 }

--- a/web/src/app/(dashboard)/settings/page.tsx
+++ b/web/src/app/(dashboard)/settings/page.tsx
@@ -1,66 +1,43 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { apiClient } from '@/lib/api-client';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { PageTransition } from '@/components/ui/PageTransition';
+import { useCurrentUser, useUpdateProfile } from '@/hooks/use-user';
 import { useAuthStore } from '@/stores/auth-store';
-
-interface UserProfile {
-  id: string;
-  display_name: string;
-  avatar_url: string | null;
-  is_guest: boolean;
-  created_at: string;
-  login_streak: number;
-  longest_streak: number;
-}
+import { apiClient } from '@/lib/api-client';
+import { toast } from '@/lib/toast';
+import { profileSchema, type ProfileFormValues } from '@/lib/schemas';
+import { FormInput } from '@/components/ui/FormInput';
 
 export default function SettingsPage() {
   const router = useRouter();
   const { signOut } = useAuthStore();
-  const [profile, setProfile] = useState<UserProfile | null>(null);
-  const [displayName, setDisplayName] = useState('');
-  const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
-  const [saved, setSaved] = useState(false);
-  const [deleting, setDeleting] = useState(false);
+  const { data: profile, isLoading } = useCurrentUser();
+  const updateProfile = useUpdateProfile();
+  const { register, handleSubmit, reset, formState: { errors, isDirty } } = useForm<ProfileFormValues>({
+    resolver: zodResolver(profileSchema),
+  });
+
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   useEffect(() => {
-    async function load() {
-      try {
-        const user = await apiClient.getMe();
-        setProfile(user);
-        setDisplayName(user.display_name);
-      } catch (err) {
-        console.error('Failed to load profile:', err);
-      } finally {
-        setLoading(false);
-      }
+    if (profile) {
+      reset({ display_name: profile.display_name });
     }
-    load();
-  }, []);
+  }, [profile, reset]);
 
-  async function handleSave() {
-    setSaving(true);
-    setSaved(false);
-    try {
-      await apiClient.request('/api/v1/auth/me', {
-        method: 'PUT',
-        body: JSON.stringify({ display_name: displayName }),
-      });
-      setSaved(true);
-      setTimeout(() => setSaved(false), 2000);
-    } catch (err) {
-      console.error('Failed to update profile:', err);
-    } finally {
-      setSaving(false);
-    }
+  function onSave(data: ProfileFormValues) {
+    updateProfile.mutate(data.display_name);
   }
 
   function handleSignOut() {
     signOut();
     apiClient.setToken(null);
+    document.cookie = 'mockstarket_token=; path=/; max-age=0';
     router.push('/');
   }
 
@@ -70,43 +47,41 @@ export default function SettingsPage() {
       await apiClient.request('/api/v1/auth/me', { method: 'DELETE' });
       signOut();
       apiClient.setToken(null);
+      document.cookie = 'mockstarket_token=; path=/; max-age=0';
       router.push('/');
-    } catch (err) {
-      console.error('Failed to delete account:', err);
+    } catch {
+      toast.error('Failed to delete account');
       setDeleting(false);
     }
   }
 
-  if (loading) {
+  if (isLoading) {
     return <div className="p-6 text-center text-[#8B949E]">Loading...</div>;
   }
 
   return (
+    <PageTransition>
     <div className="p-6 max-w-2xl mx-auto space-y-6">
       <h1 className="text-2xl font-bold">Settings</h1>
 
       {/* Profile */}
-      <div className="rounded-xl bg-[#161B22] border border-[#30363D] p-6 space-y-4">
+      <form onSubmit={handleSubmit(onSave)} className="rounded-xl bg-[#161B22] border border-[#30363D] p-6 space-y-4">
         <h2 className="font-semibold">Profile</h2>
 
-        <div>
-          <label className="block text-xs text-[#6E7681] mb-1.5">Display Name</label>
-          <input
-            type="text"
-            value={displayName}
-            onChange={(e) => setDisplayName(e.target.value)}
-            className="w-full rounded-lg bg-[#0D1117] border border-[#30363D] px-4 py-3 text-white placeholder-[#6E7681] focus:outline-none focus:border-[#50E3C2]"
-          />
-        </div>
+        <FormInput
+          label="Display Name"
+          error={errors.display_name?.message}
+          {...register('display_name')}
+        />
 
         <button
-          onClick={handleSave}
-          disabled={saving || displayName === profile?.display_name}
+          type="submit"
+          disabled={updateProfile.isPending || !isDirty}
           className="px-4 py-2 rounded-lg bg-[#50E3C2] text-[#0D1117] text-sm font-semibold hover:bg-[#3BC4A7] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          {saving ? 'Saving...' : saved ? 'Saved!' : 'Save Changes'}
+          {updateProfile.isPending ? 'Saving...' : 'Save Changes'}
         </button>
-      </div>
+      </form>
 
       {/* Account Info */}
       <div className="rounded-xl bg-[#161B22] border border-[#30363D] p-6 space-y-3">
@@ -179,5 +154,6 @@ export default function SettingsPage() {
         </div>
       </div>
     </div>
+    </PageTransition>
   );
 }

--- a/web/src/app/(dashboard)/stock/[ticker]/page.tsx
+++ b/web/src/app/(dashboard)/stock/[ticker]/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 import { apiClient } from '@/lib/api-client';
 import { formatCurrency, formatPercent, formatVolume, priceChangeColor, priceChangeBg } from '@/lib/formatters';
 import { useMarketStore } from '@/stores/market-store';
-import type { Stock, PricePoint } from '@/types/stock';
+import type { Stock, PricePoint, ETFHolding } from '@/types/stock';
 
 const PriceChart = lazy(() => import('@/components/charts/PriceChart'));
 
@@ -17,6 +17,7 @@ export default function StockDetailPage() {
 
   const [stock, setStock] = useState<Stock | null>(null);
   const [history, setHistory] = useState<PricePoint[]>([]);
+  const [etfHoldings, setEtfHoldings] = useState<ETFHolding[]>([]);
   const [interval, setInterval] = useState('1m');
   const [loading, setLoading] = useState(true);
 
@@ -36,6 +37,14 @@ export default function StockDetailPage() {
         ]);
         setStock(stockData);
         setHistory(historyData || []);
+
+        // Load ETF holdings if this is an ETF
+        if (stockData.asset_type === 'etf') {
+          try {
+            const holdings = await apiClient.getETFHoldings(ticker);
+            setEtfHoldings(holdings || []);
+          } catch { /* not an ETF or no holdings */ }
+        }
       } catch {
         console.error('Failed to load stock');
       } finally {
@@ -96,6 +105,14 @@ export default function StockDetailPage() {
               {stock.ticker}
             </span>
             <span className="text-sm text-[#8B949E]">{stock.sector}</span>
+            <span className={`text-xs font-medium px-2 py-0.5 rounded ${
+              stock.asset_type === 'crypto' ? 'bg-orange-400/10 text-orange-400' :
+              stock.asset_type === 'commodity' ? 'bg-yellow-400/10 text-yellow-400' :
+              stock.asset_type === 'etf' ? 'bg-purple-400/10 text-purple-400' :
+              'bg-[#8B949E]/10 text-[#8B949E]'
+            }`}>
+              {stock.asset_type?.toUpperCase() || 'STOCK'}
+            </span>
           </div>
           <h1 className="text-2xl font-bold">{stock.name}</h1>
           {stock.description && (
@@ -172,6 +189,31 @@ export default function StockDetailPage() {
           </div>
         )}
       </div>
+
+      {/* ETF Holdings */}
+      {stock.asset_type === 'etf' && etfHoldings.length > 0 && (
+        <div className="rounded-xl bg-[#161B22] border border-[#30363D] p-6">
+          <h2 className="font-semibold mb-4">Holdings</h2>
+          <div className="space-y-3">
+            {etfHoldings.map((h) => (
+              <div key={h.ticker} className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <Link href={`/stock/${h.ticker}`}>
+                    <span className="rounded bg-[#50E3C2]/10 px-2 py-0.5 text-xs font-mono font-bold text-[#50E3C2] hover:bg-[#50E3C2]/20 transition-colors">
+                      {h.ticker}
+                    </span>
+                  </Link>
+                  <span className="text-sm text-[#8B949E]">{h.name}</span>
+                </div>
+                <div className="flex items-center gap-4">
+                  <span className="text-sm text-[#8B949E]">{h.price ? formatCurrency(h.price) : '-'}</span>
+                  <span className="text-sm font-semibold">{(parseFloat(h.weight) * 100).toFixed(0)}%</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Trade Panel */}
       <div className="rounded-xl bg-[#161B22] border border-[#30363D] p-6">

--- a/web/src/app/(dashboard)/stock/[ticker]/page.tsx
+++ b/web/src/app/(dashboard)/stock/[ticker]/page.tsx
@@ -1,59 +1,41 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import dynamic from 'next/dynamic';
-import { apiClient } from '@/lib/api-client';
-import { formatCurrency, formatPercent, formatVolume, priceChangeColor, priceChangeBg } from '@/lib/formatters';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { PageTransition } from '@/components/ui/PageTransition';
+import { useStock, useStockHistory, useETFHoldings } from '@/hooks/use-stocks';
+import { useExecuteTrade } from '@/hooks/use-portfolio';
+import { useWatchlist, useAddToWatchlist, useRemoveFromWatchlist } from '@/hooks/use-watchlist';
+import { formatCurrency, formatPercent, formatVolume, priceChangeColor } from '@/lib/formatters';
+import { tradeSchema, type TradeFormValues } from '@/lib/schemas';
 import { useMarketStore } from '@/stores/market-store';
-import type { Stock, PricePoint, ETFHolding } from '@/types/stock';
 
 const PriceChart = dynamic(() => import('@/components/charts/PriceChart'), { ssr: false });
 
 export default function StockDetailPage() {
   const { ticker } = useParams<{ ticker: string }>();
-  const router = useRouter();
   const { stocks } = useMarketStore();
 
-  const [stock, setStock] = useState<Stock | null>(null);
-  const [history, setHistory] = useState<PricePoint[]>([]);
-  const [etfHoldings, setEtfHoldings] = useState<ETFHolding[]>([]);
+  const { data: stock, isLoading } = useStock(ticker);
   const [interval, setInterval] = useState('1m');
-  const [loading, setLoading] = useState(true);
+  const { data: history = [] } = useStockHistory(ticker, interval);
+  const { data: etfHoldings = [] } = useETFHoldings(ticker, stock?.asset_type);
+  const { data: watchlist = [] } = useWatchlist();
+  const addToWatchlist = useAddToWatchlist();
+  const removeFromWatchlist = useRemoveFromWatchlist();
+  const isWatched = watchlist.includes(ticker);
 
-  // Trade form state
+  // Trade form
   const [side, setSide] = useState<'buy' | 'sell'>('buy');
-  const [shares, setShares] = useState('');
-  const [trading, setTrading] = useState(false);
-  const [tradeResult, setTradeResult] = useState<{ success: boolean; message: string } | null>(null);
-
-  useEffect(() => {
-    async function load() {
-      setLoading(true);
-      try {
-        const [stockData, historyData] = await Promise.all([
-          apiClient.getStock(ticker),
-          apiClient.getStockHistory(ticker, interval),
-        ]);
-        setStock(stockData);
-        setHistory(historyData || []);
-
-        // Load ETF holdings if this is an ETF
-        if (stockData.asset_type === 'etf') {
-          try {
-            const holdings = await apiClient.getETFHoldings(ticker);
-            setEtfHoldings(holdings || []);
-          } catch { /* not an ETF or no holdings */ }
-        }
-      } catch {
-        console.error('Failed to load stock');
-      } finally {
-        setLoading(false);
-      }
-    }
-    load();
-  }, [ticker, interval]);
+  const executeTrade = useExecuteTrade();
+  const { register, handleSubmit, watch, reset, formState: { errors } } = useForm<TradeFormValues>({
+    resolver: zodResolver(tradeSchema),
+  });
+  const sharesValue = watch('shares');
 
   // Keep live price from market store
   const liveStock = stocks.find((s) => s.ticker === ticker);
@@ -61,29 +43,16 @@ export default function StockDetailPage() {
   const dayOpen = stock ? parseFloat(stock.day_open) : 0;
   const change = currentPrice - dayOpen;
   const changePct = dayOpen !== 0 ? (change / dayOpen) * 100 : 0;
-  const totalCost = parseFloat(shares || '0') * currentPrice;
+  const totalCost = (sharesValue || 0) * currentPrice;
 
-  async function handleTrade() {
-    const qty = parseInt(shares);
-    if (!qty || qty <= 0) return;
-
-    setTrading(true);
-    setTradeResult(null);
-    try {
-      await apiClient.executeTrade(ticker, side, qty);
-      setTradeResult({
-        success: true,
-        message: `${side === 'buy' ? 'Bought' : 'Sold'} ${qty} shares of ${ticker} at ${formatCurrency(currentPrice)}`,
-      });
-      setShares('');
-    } catch (err: any) {
-      setTradeResult({ success: false, message: err.message || 'Trade failed' });
-    } finally {
-      setTrading(false);
-    }
+  function onTrade(data: TradeFormValues) {
+    executeTrade.mutate(
+      { ticker, side, shares: data.shares },
+      { onSuccess: () => reset() }
+    );
   }
 
-  if (loading) {
+  if (isLoading) {
     return <div className="p-6 text-center text-[#8B949E]">Loading...</div>;
   }
 
@@ -92,6 +61,7 @@ export default function StockDetailPage() {
   }
 
   return (
+    <PageTransition>
     <div className="p-6 max-w-6xl mx-auto space-y-6">
       {/* Back link */}
       <Link href="/market" className="text-sm text-[#8B949E] hover:text-white transition-colors">
@@ -101,6 +71,20 @@ export default function StockDetailPage() {
       {/* Header */}
       <div className="flex items-start justify-between">
         <div>
+          <button
+            onClick={() =>
+              isWatched
+                ? removeFromWatchlist.mutate(ticker)
+                : addToWatchlist.mutate(ticker)
+            }
+            className={`float-right ml-3 mt-1 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
+              isWatched
+                ? 'border-[#50E3C2]/30 text-[#50E3C2] hover:bg-[#50E3C2]/10'
+                : 'border-[#30363D] text-[#8B949E] hover:text-white hover:border-[#50E3C2]'
+            }`}
+          >
+            {isWatched ? '★ Watching' : '☆ Watch'}
+          </button>
           <div className="flex items-center gap-3 mb-1">
             <span className="rounded bg-[#50E3C2]/10 px-2.5 py-1 text-sm font-mono font-bold text-[#50E3C2]">
               {stock.ticker}
@@ -173,15 +157,15 @@ export default function StockDetailPage() {
         </div>
 
         {history.length > 0 ? (
-            <PriceChart
-              data={history.map((p) => ({
-                time: p.recorded_at,
-                open: parseFloat(p.open as any),
-                high: parseFloat(p.high as any),
-                low: parseFloat(p.low as any),
-                close: parseFloat(p.close as any),
-              }))}
-            />
+          <PriceChart
+            data={history.map((p) => ({
+              time: p.recorded_at,
+              open: parseFloat(p.open as any),
+              high: parseFloat(p.high as any),
+              low: parseFloat(p.low as any),
+              close: parseFloat(p.close as any),
+            }))}
+          />
         ) : (
           <div className="h-[300px] flex items-center justify-center text-[#6E7681] text-sm">
             No price history yet. Data will appear as the market simulation runs.
@@ -242,53 +226,45 @@ export default function StockDetailPage() {
           </button>
         </div>
 
-        {/* Shares input */}
-        <div className="mb-4">
-          <label className="block text-xs text-[#6E7681] mb-1.5">Shares</label>
-          <input
-            type="number"
-            min="1"
-            value={shares}
-            onChange={(e) => setShares(e.target.value)}
-            placeholder="0"
-            className="w-full rounded-lg bg-[#0D1117] border border-[#30363D] px-4 py-3 text-white placeholder-[#6E7681] focus:outline-none focus:border-[#50E3C2]"
-          />
-        </div>
-
-        {/* Estimated total */}
-        {parseFloat(shares || '0') > 0 && (
-          <div className="flex justify-between text-sm mb-4 px-1">
-            <span className="text-[#8B949E]">Estimated Total</span>
-            <span className="font-semibold">{formatCurrency(totalCost)}</span>
+        {/* Trade form */}
+        <form onSubmit={handleSubmit(onTrade)}>
+          <div className="mb-4">
+            <label className="block text-xs text-[#6E7681] mb-1.5">Shares</label>
+            <input
+              type="number"
+              min="1"
+              placeholder="0"
+              {...register('shares')}
+              className={`w-full rounded-lg bg-[#0D1117] border px-4 py-3 text-white placeholder-[#6E7681] focus:outline-none ${
+                errors.shares ? 'border-red-400' : 'border-[#30363D] focus:border-[#50E3C2]'
+              }`}
+            />
+            {errors.shares && (
+              <p className="text-xs text-red-400 mt-1">{errors.shares.message}</p>
+            )}
           </div>
-        )}
 
-        {/* Submit */}
-        <button
-          onClick={handleTrade}
-          disabled={trading || !shares || parseInt(shares) <= 0}
-          className={`w-full py-3 rounded-lg text-sm font-semibold transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
-            side === 'buy'
-              ? 'bg-emerald-500 hover:bg-emerald-600 text-white'
-              : 'bg-red-500 hover:bg-red-600 text-white'
-          }`}
-        >
-          {trading ? 'Processing...' : `${side === 'buy' ? 'Buy' : 'Sell'} ${stock.ticker}`}
-        </button>
+          {totalCost > 0 && (
+            <div className="flex justify-between text-sm mb-4 px-1">
+              <span className="text-[#8B949E]">Estimated Total</span>
+              <span className="font-semibold">{formatCurrency(totalCost)}</span>
+            </div>
+          )}
 
-        {/* Trade result */}
-        {tradeResult && (
-          <div
-            className={`mt-3 rounded-lg px-4 py-3 text-sm ${
-              tradeResult.success
-                ? 'bg-emerald-500/10 text-emerald-400'
-                : 'bg-red-500/10 text-red-400'
+          <button
+            type="submit"
+            disabled={executeTrade.isPending}
+            className={`w-full py-3 rounded-lg text-sm font-semibold transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+              side === 'buy'
+                ? 'bg-emerald-500 hover:bg-emerald-600 text-white'
+                : 'bg-red-500 hover:bg-red-600 text-white'
             }`}
           >
-            {tradeResult.message}
-          </div>
-        )}
+            {executeTrade.isPending ? 'Processing...' : `${side === 'buy' ? 'Buy' : 'Sell'} ${stock.ticker}`}
+          </button>
+        </form>
       </div>
     </div>
+    </PageTransition>
   );
 }

--- a/web/src/app/(dashboard)/stock/[ticker]/page.tsx
+++ b/web/src/app/(dashboard)/stock/[ticker]/page.tsx
@@ -1,14 +1,15 @@
 'use client';
 
-import { useEffect, useState, lazy, Suspense } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
+import dynamic from 'next/dynamic';
 import { apiClient } from '@/lib/api-client';
 import { formatCurrency, formatPercent, formatVolume, priceChangeColor, priceChangeBg } from '@/lib/formatters';
 import { useMarketStore } from '@/stores/market-store';
 import type { Stock, PricePoint, ETFHolding } from '@/types/stock';
 
-const PriceChart = lazy(() => import('@/components/charts/PriceChart'));
+const PriceChart = dynamic(() => import('@/components/charts/PriceChart'), { ssr: false });
 
 export default function StockDetailPage() {
   const { ticker } = useParams<{ ticker: string }>();
@@ -172,7 +173,6 @@ export default function StockDetailPage() {
         </div>
 
         {history.length > 0 ? (
-          <Suspense fallback={<div className="h-[300px] flex items-center justify-center text-[#8B949E]">Loading chart...</div>}>
             <PriceChart
               data={history.map((p) => ({
                 time: p.recorded_at,
@@ -182,7 +182,6 @@ export default function StockDetailPage() {
                 close: parseFloat(p.close as any),
               }))}
             />
-          </Suspense>
         ) : (
           <div className="h-[300px] flex items-center justify-center text-[#6E7681] text-sm">
             No price history yet. Data will appear as the market simulation runs.

--- a/web/src/app/(dashboard)/watchlist/page.tsx
+++ b/web/src/app/(dashboard)/watchlist/page.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { PageTransition } from '@/components/ui/PageTransition';
+import { useWatchlist, useAddToWatchlist, useRemoveFromWatchlist } from '@/hooks/use-watchlist';
+import { useMarketStore } from '@/stores/market-store';
+import { formatCurrency, formatPercent, priceChangeBg } from '@/lib/formatters';
+
+export default function WatchlistPage() {
+  const { data: watchedTickers = [], isLoading } = useWatchlist();
+  const { stocks } = useMarketStore();
+  const addToWatchlist = useAddToWatchlist();
+  const removeFromWatchlist = useRemoveFromWatchlist();
+
+  const [showAdd, setShowAdd] = useState(false);
+  const [search, setSearch] = useState('');
+
+  const watchedStocks = watchedTickers
+    .map((ticker) => stocks.find((s) => s.ticker === ticker))
+    .filter(Boolean);
+
+  const searchResults = search.length > 0
+    ? stocks.filter(
+        (s) =>
+          !watchedTickers.includes(s.ticker) &&
+          (s.ticker.toLowerCase().includes(search.toLowerCase()) ||
+            s.name.toLowerCase().includes(search.toLowerCase()))
+      ).slice(0, 8)
+    : [];
+
+  return (
+    <PageTransition>
+    <div className="p-6 max-w-4xl mx-auto space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Watchlist</h1>
+        <button
+          onClick={() => setShowAdd(!showAdd)}
+          className="px-4 py-2 rounded-lg bg-[#50E3C2] text-[#0D1117] text-sm font-semibold hover:bg-[#3BC4A7] transition-colors"
+        >
+          {showAdd ? 'Done' : 'Add Stock'}
+        </button>
+      </div>
+
+      {/* Add to watchlist search */}
+      {showAdd && (
+        <div className="rounded-xl bg-[#161B22] border border-[#30363D] p-4 space-y-3">
+          <input
+            type="text"
+            placeholder="Search stocks to add..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full rounded-lg bg-[#0D1117] border border-[#30363D] px-4 py-2.5 text-sm text-white placeholder-[#6E7681] focus:outline-none focus:border-[#50E3C2]"
+            autoFocus
+          />
+          {searchResults.length > 0 && (
+            <div className="space-y-1">
+              {searchResults.map((stock) => (
+                <div
+                  key={stock.ticker}
+                  className="flex items-center justify-between px-3 py-2 rounded-lg hover:bg-[#21262D] transition-colors"
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="rounded bg-[#50E3C2]/10 px-2 py-0.5 text-xs font-mono font-bold text-[#50E3C2]">
+                      {stock.ticker}
+                    </span>
+                    <span className="text-sm text-[#8B949E]">{stock.name}</span>
+                  </div>
+                  <button
+                    onClick={() => {
+                      addToWatchlist.mutate(stock.ticker);
+                      setSearch('');
+                    }}
+                    className="text-xs text-[#50E3C2] hover:text-[#3BC4A7] font-medium transition-colors"
+                  >
+                    + Add
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+          {search.length > 0 && searchResults.length === 0 && (
+            <p className="text-sm text-[#6E7681] px-3">No stocks found</p>
+          )}
+        </div>
+      )}
+
+      {/* Watchlist table */}
+      <div className="rounded-xl bg-[#161B22] border border-[#30363D] overflow-hidden">
+        {isLoading ? (
+          <div className="p-8 text-center text-[#8B949E]">Loading watchlist...</div>
+        ) : watchedStocks.length === 0 ? (
+          <div className="p-8 text-center text-[#8B949E]">
+            <p>Your watchlist is empty.</p>
+            <p className="mt-1 text-sm">Add stocks you want to track.</p>
+          </div>
+        ) : (
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-[#30363D] text-xs text-[#8B949E] uppercase">
+                <th className="text-left px-4 py-3">Stock</th>
+                <th className="text-right px-4 py-3">Price</th>
+                <th className="text-right px-4 py-3">Change</th>
+                <th className="text-right px-4 py-3 w-20">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {watchedStocks.map((stock) => {
+                if (!stock) return null;
+                const change = parseFloat(stock.current_price) - parseFloat(stock.day_open);
+                const changePct = parseFloat(stock.day_open) !== 0 ? (change / parseFloat(stock.day_open)) * 100 : 0;
+
+                return (
+                  <tr key={stock.ticker} className="border-b border-[#21262D] hover:bg-[#21262D] transition-colors">
+                    <td className="px-4 py-3">
+                      <Link href={`/stock/${stock.ticker}`} className="flex items-center gap-3">
+                        <span className="rounded bg-[#50E3C2]/10 px-2 py-1 text-xs font-mono font-bold text-[#50E3C2]">
+                          {stock.ticker}
+                        </span>
+                        <span className="text-sm font-medium text-white">{stock.name}</span>
+                      </Link>
+                    </td>
+                    <td className="px-4 py-3 text-right text-sm font-semibold text-white">
+                      {formatCurrency(stock.current_price)}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <span className={`inline-block rounded-md px-2 py-1 text-xs font-semibold ${priceChangeBg(changePct)}`}>
+                        {formatPercent(changePct)}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <button
+                        onClick={() => removeFromWatchlist.mutate(stock.ticker)}
+                        className="text-xs text-red-400 hover:text-red-300 transition-colors"
+                      >
+                        Remove
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+    </PageTransition>
+  );
+}

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next';
+import { Providers } from './providers';
+import { ToastContainer } from '@/components/ui/Toast';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -14,7 +16,10 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark">
       <body className="bg-[#0D1117] text-[#E6EDF3] antialiased">
-        {children}
+        <Providers>
+          {children}
+          <ToastContainer />
+        </Providers>
       </body>
     </html>
   );

--- a/web/src/app/providers.tsx
+++ b/web/src/app/providers.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useState } from 'react';
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 30_000,
+            retry: 1,
+            refetchOnWindowFocus: true,
+          },
+        },
+      })
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  );
+}

--- a/web/src/components/charts/PortfolioChart.tsx
+++ b/web/src/components/charts/PortfolioChart.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { createChart, type IChartApi, ColorType } from 'lightweight-charts';
+
+interface PortfolioChartProps {
+  data: Array<{ time: string; value: number }>;
+}
+
+export default function PortfolioChart({ data }: PortfolioChartProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<IChartApi | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current || data.length === 0) return;
+
+    const chart = createChart(containerRef.current, {
+      layout: {
+        background: { type: ColorType.Solid, color: 'transparent' },
+        textColor: '#8B949E',
+      },
+      grid: {
+        vertLines: { color: '#21262D' },
+        horzLines: { color: '#21262D' },
+      },
+      width: containerRef.current.clientWidth,
+      height: 250,
+      timeScale: {
+        borderColor: '#30363D',
+        timeVisible: true,
+      },
+      rightPriceScale: {
+        borderColor: '#30363D',
+      },
+      crosshair: {
+        horzLine: { color: '#50E3C2', style: 3 },
+        vertLine: { color: '#50E3C2', style: 3 },
+      },
+    });
+
+    const series = chart.addAreaSeries({
+      lineColor: '#50E3C2',
+      topColor: 'rgba(80, 227, 194, 0.2)',
+      bottomColor: 'rgba(80, 227, 194, 0)',
+      lineWidth: 2,
+    });
+
+    const formatted = data.map((d) => ({
+      time: d.time as any,
+      value: d.value,
+    }));
+
+    series.setData(formatted);
+    chart.timeScale().fitContent();
+    chartRef.current = chart;
+
+    const handleResize = () => {
+      if (containerRef.current) {
+        chart.applyOptions({ width: containerRef.current.clientWidth });
+      }
+    };
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      chart.remove();
+    };
+  }, [data]);
+
+  return <div ref={containerRef} />;
+}

--- a/web/src/components/charts/PriceChart.tsx
+++ b/web/src/components/charts/PriceChart.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { createChart, ColorType, type IChartApi, type ISeriesApi, type LineData, type Time } from 'lightweight-charts';
+import { createChart, ColorType, type IChartApi, type ISeriesApi, type Time } from 'lightweight-charts';
 
 interface PriceChartProps {
   data: Array<{

--- a/web/src/components/ui/CardSkeleton.tsx
+++ b/web/src/components/ui/CardSkeleton.tsx
@@ -1,0 +1,11 @@
+import { Skeleton } from './Skeleton';
+
+export function CardSkeleton() {
+  return (
+    <div className="rounded-xl bg-[#161B22] border border-[#30363D] p-4 space-y-2">
+      <Skeleton className="h-3 w-16" />
+      <Skeleton className="h-6 w-24" />
+      <Skeleton className="h-3 w-20" />
+    </div>
+  );
+}

--- a/web/src/components/ui/ConnectionStatus.tsx
+++ b/web/src/components/ui/ConnectionStatus.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { wsClient, type ConnectionStatus as Status } from '@/lib/websocket-client';
+import { cn } from '@/lib/cn';
+
+const statusConfig: Record<Status, { color: string; label: string }> = {
+  connected: { color: 'bg-emerald-400', label: 'Connected' },
+  reconnecting: { color: 'bg-yellow-400 animate-pulse', label: 'Reconnecting...' },
+  disconnected: { color: 'bg-red-400', label: 'Disconnected' },
+};
+
+export function ConnectionStatus() {
+  const [status, setStatus] = useState<Status>(wsClient.status);
+
+  useEffect(() => {
+    return wsClient.onStatusChange(setStatus);
+  }, []);
+
+  const config = statusConfig[status];
+
+  return (
+    <div className="flex items-center gap-2 text-xs text-[#6E7681]">
+      <span className={cn('w-2 h-2 rounded-full', config.color)} />
+      {config.label}
+    </div>
+  );
+}

--- a/web/src/components/ui/FormInput.tsx
+++ b/web/src/components/ui/FormInput.tsx
@@ -1,0 +1,29 @@
+import { forwardRef } from 'react';
+import { cn } from '@/lib/cn';
+
+interface FormInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label: string;
+  error?: string;
+}
+
+export const FormInput = forwardRef<HTMLInputElement, FormInputProps>(
+  ({ label, error, className, ...props }, ref) => {
+    return (
+      <div>
+        <label className="block text-xs text-[#6E7681] mb-1.5">{label}</label>
+        <input
+          ref={ref}
+          className={cn(
+            'w-full rounded-lg bg-[#0D1117] border px-4 py-2.5 text-white placeholder-[#6E7681] focus:outline-none text-sm',
+            error ? 'border-red-400 focus:border-red-400' : 'border-[#30363D] focus:border-[#50E3C2]',
+            className
+          )}
+          {...props}
+        />
+        {error && <p className="text-xs text-red-400 mt-1">{error}</p>}
+      </div>
+    );
+  }
+);
+
+FormInput.displayName = 'FormInput';

--- a/web/src/components/ui/PageTransition.tsx
+++ b/web/src/components/ui/PageTransition.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { motion } from 'framer-motion';
+
+export function PageTransition({ children }: { children: React.ReactNode }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.2, ease: 'easeOut' }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/web/src/components/ui/Skeleton.tsx
+++ b/web/src/components/ui/Skeleton.tsx
@@ -1,0 +1,7 @@
+import { cn } from '@/lib/cn';
+
+export function Skeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn('animate-pulse rounded bg-[#21262D]', className)} />
+  );
+}

--- a/web/src/components/ui/TableSkeleton.tsx
+++ b/web/src/components/ui/TableSkeleton.tsx
@@ -1,0 +1,15 @@
+import { Skeleton } from './Skeleton';
+
+export function TableSkeleton({ rows = 5, columns = 4 }: { rows?: number; columns?: number }) {
+  return (
+    <div className="space-y-0">
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} className="flex items-center gap-4 px-4 py-3.5 border-b border-[#21262D]">
+          {Array.from({ length: columns }).map((_, j) => (
+            <Skeleton key={j} className={`h-4 ${j === 0 ? 'w-20' : 'flex-1'}`} />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { AnimatePresence, motion } from 'framer-motion';
+import { CheckCircle2, AlertCircle, Info, AlertTriangle, X } from 'lucide-react';
+import { useToastStore, type ToastType } from '@/stores/toast-store';
+
+const icons: Record<ToastType, React.ReactNode> = {
+  success: <CheckCircle2 className="w-5 h-5 text-emerald-400" />,
+  error: <AlertCircle className="w-5 h-5 text-red-400" />,
+  info: <Info className="w-5 h-5 text-blue-400" />,
+  warning: <AlertTriangle className="w-5 h-5 text-yellow-400" />,
+};
+
+const borderColors: Record<ToastType, string> = {
+  success: 'border-emerald-400/30',
+  error: 'border-red-400/30',
+  info: 'border-blue-400/30',
+  warning: 'border-yellow-400/30',
+};
+
+export function ToastContainer() {
+  const toasts = useToastStore((s) => s.toasts);
+  const removeToast = useToastStore((s) => s.removeToast);
+
+  return (
+    <div className="fixed top-4 right-4 z-50 flex flex-col gap-2 max-w-sm">
+      <AnimatePresence>
+        {toasts.map((t) => (
+          <motion.div
+            key={t.id}
+            initial={{ opacity: 0, x: 50, scale: 0.95 }}
+            animate={{ opacity: 1, x: 0, scale: 1 }}
+            exit={{ opacity: 0, x: 50, scale: 0.95 }}
+            transition={{ duration: 0.2 }}
+            className={`flex items-start gap-3 px-4 py-3 rounded-lg border bg-[#161B22] ${borderColors[t.type]}`}
+          >
+            <div className="mt-0.5 shrink-0">{icons[t.type]}</div>
+            <p className="text-sm text-[#E6EDF3] flex-1">{t.message}</p>
+            <button
+              onClick={() => removeToast(t.id)}
+              className="shrink-0 text-[#6E7681] hover:text-[#E6EDF3] transition-colors"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </motion.div>
+        ))}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/web/src/hooks/__tests__/use-achievements.test.ts
+++ b/web/src/hooks/__tests__/use-achievements.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useAchievements } from '../use-achievements';
+import { createWrapper } from '@/test/test-utils';
+import { apiClient } from '@/lib/api-client';
+
+beforeEach(() => {
+  apiClient.setToken('test-token');
+});
+
+describe('useAchievements', () => {
+  it('fetches achievements and earned data together', async () => {
+    const { result } = renderHook(() => useAchievements(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.achievements).toHaveLength(1);
+    expect(result.current.data?.achievements[0].name).toBe('First Trade');
+    expect(result.current.data?.earned).toHaveLength(1);
+    expect(result.current.data?.earned[0].achievement_id).toBe('ach-1');
+  });
+});

--- a/web/src/hooks/__tests__/use-alerts.test.ts
+++ b/web/src/hooks/__tests__/use-alerts.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useAlerts, useCreateAlert, useDeleteAlert } from '../use-alerts';
+import { createWrapper } from '@/test/test-utils';
+import { apiClient } from '@/lib/api-client';
+
+beforeEach(() => {
+  apiClient.setToken('test-token');
+});
+
+describe('useAlerts', () => {
+  it('fetches alerts and separates active/triggered', async () => {
+    const { result } = renderHook(() => useAlerts(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toHaveLength(2);
+    const active = result.current.data!.filter((a) => !a.triggered);
+    const triggered = result.current.data!.filter((a) => a.triggered);
+    expect(active).toHaveLength(1);
+    expect(triggered).toHaveLength(1);
+  });
+});
+
+describe('useCreateAlert', () => {
+  it('creates a price alert', async () => {
+    const { result } = renderHook(() => useCreateAlert(), { wrapper: createWrapper() });
+
+    result.current.mutate({ ticker: 'PIPE', condition: 'above', targetPrice: '160.00' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});
+
+describe('useDeleteAlert', () => {
+  it('deletes an alert', async () => {
+    const { result } = renderHook(() => useDeleteAlert(), { wrapper: createWrapper() });
+
+    result.current.mutate('alert-1');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});

--- a/web/src/hooks/__tests__/use-challenges.test.ts
+++ b/web/src/hooks/__tests__/use-challenges.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useTodaysChallenge, useCheckChallenge } from '../use-challenges';
+import { createWrapper } from '@/test/test-utils';
+import { apiClient } from '@/lib/api-client';
+
+beforeEach(() => {
+  apiClient.setToken('test-token');
+});
+
+describe('useTodaysChallenge', () => {
+  it('fetches todays challenge with progress', async () => {
+    const { result } = renderHook(() => useTodaysChallenge(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.challenge?.challenge_type).toBe('trade_count');
+    expect(result.current.data?.challenge?.description).toBe('Execute 3 trades today');
+    expect(result.current.data?.progress?.completed).toBe(false);
+    expect(result.current.data?.progress?.claimed).toBe(false);
+  });
+});
+
+describe('useCheckChallenge', () => {
+  it('checks challenge completion', async () => {
+    const { result } = renderHook(() => useCheckChallenge(), { wrapper: createWrapper() });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data.completed).toBe(false);
+  });
+});

--- a/web/src/hooks/__tests__/use-leaderboard.test.ts
+++ b/web/src/hooks/__tests__/use-leaderboard.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useLeaderboard } from '../use-leaderboard';
+import { createWrapper } from '@/test/test-utils';
+import { apiClient } from '@/lib/api-client';
+
+beforeEach(() => {
+  apiClient.setToken('test-token');
+});
+
+describe('useLeaderboard', () => {
+  it('fetches leaderboard entries', async () => {
+    const { result } = renderHook(() => useLeaderboard('alltime'), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toHaveLength(2);
+    expect(result.current.data![0].rank).toBe(1);
+    expect(result.current.data![0].display_name).toBe('TraderJoe');
+  });
+});

--- a/web/src/hooks/__tests__/use-orders.test.ts
+++ b/web/src/hooks/__tests__/use-orders.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useOrders, useCreateOrder, useCancelOrder } from '../use-orders';
+import { createWrapper } from '@/test/test-utils';
+import { apiClient } from '@/lib/api-client';
+
+beforeEach(() => {
+  apiClient.setToken('test-token');
+});
+
+describe('useOrders', () => {
+  it('fetches open orders', async () => {
+    const { result } = renderHook(() => useOrders(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data![0].ticker).toBe('PIPE');
+    expect(result.current.data![0].order_type).toBe('limit');
+  });
+});
+
+describe('useCreateOrder', () => {
+  it('creates an order', async () => {
+    const { result } = renderHook(() => useCreateOrder(), { wrapper: createWrapper() });
+
+    result.current.mutate({
+      ticker: 'PIPE',
+      side: 'buy',
+      orderType: 'limit',
+      shares: 50,
+      limitPrice: '145.00',
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});
+
+describe('useCancelOrder', () => {
+  it('cancels an order', async () => {
+    const { result } = renderHook(() => useCancelOrder(), { wrapper: createWrapper() });
+
+    result.current.mutate('order-1');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});

--- a/web/src/hooks/__tests__/use-portfolio.test.ts
+++ b/web/src/hooks/__tests__/use-portfolio.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { usePortfolio, useTradeHistory, useExecuteTrade } from '../use-portfolio';
+import { createWrapper } from '@/test/test-utils';
+import { apiClient } from '@/lib/api-client';
+
+beforeEach(() => {
+  apiClient.setToken('test-token');
+});
+
+describe('usePortfolio', () => {
+  it('fetches portfolio with positions', async () => {
+    const { result } = renderHook(() => usePortfolio(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.net_worth).toBe('105000.00');
+    expect(result.current.data?.portfolio.cash).toBe('85000.00');
+    expect(result.current.data?.positions).toHaveLength(1);
+    expect(result.current.data?.positions[0].ticker).toBe('PIPE');
+  });
+});
+
+describe('useTradeHistory', () => {
+  it('fetches trade history', async () => {
+    const { result } = renderHook(() => useTradeHistory(50, 0), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data![0].ticker).toBe('PIPE');
+    expect(result.current.data![0].side).toBe('buy');
+  });
+});
+
+describe('useExecuteTrade', () => {
+  it('executes a trade successfully', async () => {
+    const { result } = renderHook(() => useExecuteTrade(), { wrapper: createWrapper() });
+
+    result.current.mutate({ ticker: 'PIPE', side: 'buy', shares: 10 });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data.ticker).toBe('PIPE');
+    expect(result.current.data.shares).toBe(10);
+  });
+});

--- a/web/src/hooks/__tests__/use-stocks.test.ts
+++ b/web/src/hooks/__tests__/use-stocks.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useStocks, useStock, useMarketSummary } from '../use-stocks';
+import { createWrapper } from '@/test/test-utils';
+import { mockStocks, mockMarketSummary } from '@/test/mocks/handlers';
+import { apiClient } from '@/lib/api-client';
+import { useMarketStore } from '@/stores/market-store';
+
+beforeEach(() => {
+  apiClient.setToken('test-token');
+  useMarketStore.setState({ stocks: [], summary: null });
+});
+
+describe('useStocks', () => {
+  it('fetches stocks and syncs to market store', async () => {
+    const { result } = renderHook(() => useStocks(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toHaveLength(mockStocks.length);
+    expect(result.current.data![0].ticker).toBe('PIPE');
+
+    // Should sync to Zustand store
+    expect(useMarketStore.getState().stocks).toHaveLength(mockStocks.length);
+  });
+});
+
+describe('useStock', () => {
+  it('fetches a single stock by ticker', async () => {
+    const { result } = renderHook(() => useStock('PIPE'), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.ticker).toBe('PIPE');
+    expect(result.current.data?.name).toBe('Piper Industries');
+  });
+});
+
+describe('useMarketSummary', () => {
+  it('fetches market summary', async () => {
+    const { result } = renderHook(() => useMarketSummary(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.total_stocks).toBe(mockMarketSummary.total_stocks);
+    expect(result.current.data?.gainers).toBe(2);
+    expect(result.current.data?.losers).toBe(1);
+  });
+});

--- a/web/src/hooks/__tests__/use-user.test.ts
+++ b/web/src/hooks/__tests__/use-user.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useCurrentUser, useUpdateProfile } from '../use-user';
+import { createWrapper } from '@/test/test-utils';
+import { apiClient } from '@/lib/api-client';
+import { mockUser } from '@/test/mocks/handlers';
+
+beforeEach(() => {
+  apiClient.setToken('test-token');
+});
+
+describe('useCurrentUser', () => {
+  it('fetches current user profile', async () => {
+    const { result } = renderHook(() => useCurrentUser(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.display_name).toBe(mockUser.display_name);
+    expect(result.current.data?.is_guest).toBe(true);
+    expect(result.current.data?.login_streak).toBe(5);
+  });
+});
+
+describe('useUpdateProfile', () => {
+  it('updates display name', async () => {
+    const { result } = renderHook(() => useUpdateProfile(), { wrapper: createWrapper() });
+
+    result.current.mutate('NewName');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});

--- a/web/src/hooks/__tests__/use-watchlist.test.ts
+++ b/web/src/hooks/__tests__/use-watchlist.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useWatchlist, useAddToWatchlist, useRemoveFromWatchlist } from '../use-watchlist';
+import { createWrapper } from '@/test/test-utils';
+import { apiClient } from '@/lib/api-client';
+
+beforeEach(() => {
+  apiClient.setToken('test-token');
+});
+
+describe('useWatchlist', () => {
+  it('fetches watchlist tickers', async () => {
+    const { result } = renderHook(() => useWatchlist(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(['PIPE', 'BREW']);
+  });
+});
+
+describe('useAddToWatchlist', () => {
+  it('adds a stock to watchlist', async () => {
+    const { result } = renderHook(() => useAddToWatchlist(), { wrapper: createWrapper() });
+
+    result.current.mutate('GLDX');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});
+
+describe('useRemoveFromWatchlist', () => {
+  it('removes a stock from watchlist', async () => {
+    const { result } = renderHook(() => useRemoveFromWatchlist(), { wrapper: createWrapper() });
+
+    result.current.mutate('PIPE');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});

--- a/web/src/hooks/use-achievements.ts
+++ b/web/src/hooks/use-achievements.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/lib/api-client';
+import type { Achievement } from '@/types/user';
+
+export interface UserAchievement {
+  id: string;
+  achievement_id: string;
+  earned_at: string;
+}
+
+export function useAchievements() {
+  return useQuery<{ achievements: Achievement[]; earned: UserAchievement[] }>({
+    queryKey: ['achievements'],
+    queryFn: async () => {
+      const [achievements, earned] = await Promise.all([
+        apiClient.getAchievements(),
+        apiClient.getMyAchievements(),
+      ]);
+      return {
+        achievements: achievements || [],
+        earned: earned || [],
+      };
+    },
+  });
+}

--- a/web/src/hooks/use-alerts.ts
+++ b/web/src/hooks/use-alerts.ts
@@ -1,0 +1,62 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/lib/api-client';
+import { toast } from '@/lib/toast';
+
+export interface PriceAlert {
+  id: string;
+  ticker: string;
+  condition: string;
+  target_price: string;
+  triggered: boolean;
+  triggered_at: string | null;
+  created_at: string;
+}
+
+export function useAlerts() {
+  return useQuery<PriceAlert[]>({
+    queryKey: ['alerts'],
+    queryFn: async () => {
+      const data = await apiClient.getAlerts();
+      return data || [];
+    },
+  });
+}
+
+export function useCreateAlert() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (params: { ticker: string; condition: string; targetPrice: string }) =>
+      apiClient.createAlert(params.ticker, params.condition, params.targetPrice),
+    onSuccess: () => {
+      toast.success('Price alert created');
+      queryClient.invalidateQueries({ queryKey: ['alerts'] });
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || 'Failed to create alert');
+    },
+  });
+}
+
+export function useDeleteAlert() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => apiClient.deleteAlert(id),
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: ['alerts'] });
+      const previous = queryClient.getQueryData<PriceAlert[]>(['alerts']);
+      queryClient.setQueryData<PriceAlert[]>(['alerts'], (old) =>
+        old?.filter((a) => a.id !== id)
+      );
+      return { previous };
+    },
+    onError: (_err, _id, context) => {
+      queryClient.setQueryData(['alerts'], context?.previous);
+      toast.error('Failed to delete alert');
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['alerts'] });
+    },
+  });
+}

--- a/web/src/hooks/use-challenges.ts
+++ b/web/src/hooks/use-challenges.ts
@@ -1,0 +1,71 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/lib/api-client';
+import { toast } from '@/lib/toast';
+
+interface DailyChallenge {
+  id: string;
+  date: string;
+  challenge_type: string;
+  description: string;
+  reward_cash: string;
+}
+
+interface UserProgress {
+  completed: boolean;
+  completed_at: string | null;
+  claimed: boolean;
+}
+
+export interface ChallengeData {
+  challenge: DailyChallenge | null;
+  progress: UserProgress | null;
+}
+
+export function useTodaysChallenge() {
+  return useQuery<ChallengeData>({
+    queryKey: ['challenge'],
+    queryFn: async () => {
+      try {
+        const data = await apiClient.getTodaysChallenge();
+        return { challenge: data.challenge, progress: data.progress };
+      } catch {
+        return { challenge: null, progress: null };
+      }
+    },
+  });
+}
+
+export function useCheckChallenge() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => apiClient.checkChallenge(),
+    onSuccess: (result) => {
+      if (result.completed) {
+        toast.success('Challenge completed! Claim your reward.');
+      } else {
+        toast.info('Not yet complete. Keep trading!');
+      }
+      queryClient.invalidateQueries({ queryKey: ['challenge'] });
+    },
+    onError: () => {
+      toast.error('Failed to check progress');
+    },
+  });
+}
+
+export function useClaimChallenge() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => apiClient.claimChallenge(id),
+    onSuccess: () => {
+      toast.success('Reward claimed! Cash added to your portfolio.');
+      queryClient.invalidateQueries({ queryKey: ['challenge'] });
+      queryClient.invalidateQueries({ queryKey: ['portfolio'] });
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || 'Failed to claim reward');
+    },
+  });
+}

--- a/web/src/hooks/use-debounce.ts
+++ b/web/src/hooks/use-debounce.ts
@@ -1,0 +1,12 @@
+import { useState, useEffect } from 'react';
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debounced;
+}

--- a/web/src/hooks/use-leaderboard.ts
+++ b/web/src/hooks/use-leaderboard.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/lib/api-client';
+import type { LeaderboardEntry } from '@/types/user';
+
+export function useLeaderboard(period: string) {
+  return useQuery<LeaderboardEntry[]>({
+    queryKey: ['leaderboard', period],
+    queryFn: async () => {
+      const data = await apiClient.getLeaderboard(period);
+      return data || [];
+    },
+  });
+}

--- a/web/src/hooks/use-orders.ts
+++ b/web/src/hooks/use-orders.ts
@@ -1,0 +1,70 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/lib/api-client';
+import { toast } from '@/lib/toast';
+import type { Order } from '@/types/portfolio';
+
+export function useOrders() {
+  return useQuery<Order[]>({
+    queryKey: ['orders'],
+    queryFn: async () => {
+      const data = await apiClient.getOrders();
+      return data || [];
+    },
+  });
+}
+
+export function useCreateOrder() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (params: {
+      ticker: string;
+      side: string;
+      orderType: string;
+      shares: number;
+      limitPrice?: string;
+      stopPrice?: string;
+    }) =>
+      apiClient.createOrder(
+        params.ticker,
+        params.side,
+        params.orderType,
+        params.shares,
+        params.limitPrice,
+        params.stopPrice
+      ),
+    onSuccess: () => {
+      toast.success('Order placed successfully');
+      queryClient.invalidateQueries({ queryKey: ['orders'] });
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || 'Failed to create order');
+    },
+  });
+}
+
+export function useCancelOrder() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => apiClient.cancelOrder(id),
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: ['orders'] });
+      const previous = queryClient.getQueryData<Order[]>(['orders']);
+      queryClient.setQueryData<Order[]>(['orders'], (old) =>
+        old?.filter((o) => o.id !== id)
+      );
+      return { previous };
+    },
+    onError: (_err, _id, context) => {
+      queryClient.setQueryData(['orders'], context?.previous);
+      toast.error('Failed to cancel order');
+    },
+    onSuccess: () => {
+      toast.success('Order cancelled');
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['orders'] });
+    },
+  });
+}

--- a/web/src/hooks/use-portfolio.ts
+++ b/web/src/hooks/use-portfolio.ts
@@ -1,0 +1,46 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/lib/api-client';
+import { toast } from '@/lib/toast';
+import type { PortfolioResponse, Trade } from '@/types/portfolio';
+
+export function usePortfolio() {
+  return useQuery<PortfolioResponse>({
+    queryKey: ['portfolio'],
+    queryFn: () => apiClient.getPortfolio(),
+  });
+}
+
+export function usePortfolioHistory(limit = 100) {
+  return useQuery<any[]>({
+    queryKey: ['portfolio-history', limit],
+    queryFn: () => apiClient.getPortfolioHistory(limit),
+  });
+}
+
+export function useTradeHistory(limit = 50, offset = 0) {
+  return useQuery<Trade[]>({
+    queryKey: ['trades', limit, offset],
+    queryFn: async () => {
+      const data = await apiClient.getTradeHistory(limit, offset);
+      return data || [];
+    },
+  });
+}
+
+export function useExecuteTrade() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ ticker, side, shares }: { ticker: string; side: string; shares: number }) =>
+      apiClient.executeTrade(ticker, side, shares),
+    onSuccess: (_data, variables) => {
+      const action = variables.side === 'buy' ? 'Bought' : 'Sold';
+      toast.success(`${action} ${variables.shares} shares of ${variables.ticker}`);
+      queryClient.invalidateQueries({ queryKey: ['portfolio'] });
+      queryClient.invalidateQueries({ queryKey: ['trades'] });
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || 'Trade failed');
+    },
+  });
+}

--- a/web/src/hooks/use-sort.ts
+++ b/web/src/hooks/use-sort.ts
@@ -1,0 +1,44 @@
+import { useState, useMemo } from 'react';
+
+type SortDirection = 'asc' | 'desc';
+
+export function useSort<T>(data: T[], defaultKey: keyof T, defaultDir: SortDirection = 'asc') {
+  const [sortKey, setSortKey] = useState<keyof T>(defaultKey);
+  const [sortDirection, setSortDirection] = useState<SortDirection>(defaultDir);
+
+  const sorted = useMemo(() => {
+    return [...data].sort((a, b) => {
+      const aVal = a[sortKey];
+      const bVal = b[sortKey];
+
+      let cmp: number;
+      if (typeof aVal === 'string' && typeof bVal === 'string') {
+        // Try numeric comparison for string numbers
+        const aNum = parseFloat(aVal);
+        const bNum = parseFloat(bVal);
+        if (!isNaN(aNum) && !isNaN(bNum)) {
+          cmp = aNum - bNum;
+        } else {
+          cmp = aVal.localeCompare(bVal);
+        }
+      } else if (typeof aVal === 'number' && typeof bVal === 'number') {
+        cmp = aVal - bVal;
+      } else {
+        cmp = String(aVal).localeCompare(String(bVal));
+      }
+
+      return sortDirection === 'asc' ? cmp : -cmp;
+    });
+  }, [data, sortKey, sortDirection]);
+
+  function onSort(key: keyof T) {
+    if (key === sortKey) {
+      setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDirection('asc');
+    }
+  }
+
+  return { sorted, sortKey, sortDirection, onSort };
+}

--- a/web/src/hooks/use-stocks.ts
+++ b/web/src/hooks/use-stocks.ts
@@ -1,0 +1,54 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/lib/api-client';
+import { useMarketStore } from '@/stores/market-store';
+import type { Stock, PricePoint, ETFHolding, MarketSummary } from '@/types/stock';
+
+export function useStocks() {
+  const setStocks = useMarketStore((s) => s.setStocks);
+
+  return useQuery<Stock[]>({
+    queryKey: ['stocks'],
+    queryFn: async () => {
+      const data = await apiClient.getStocks();
+      setStocks(data);
+      return data;
+    },
+  });
+}
+
+export function useStock(ticker: string) {
+  return useQuery<Stock>({
+    queryKey: ['stock', ticker],
+    queryFn: () => apiClient.getStock(ticker),
+    enabled: !!ticker,
+  });
+}
+
+export function useStockHistory(ticker: string, interval: string) {
+  return useQuery<PricePoint[]>({
+    queryKey: ['stock-history', ticker, interval],
+    queryFn: () => apiClient.getStockHistory(ticker, interval),
+    enabled: !!ticker,
+  });
+}
+
+export function useETFHoldings(ticker: string, assetType?: string) {
+  return useQuery<ETFHolding[]>({
+    queryKey: ['etf-holdings', ticker],
+    queryFn: () => apiClient.getETFHoldings(ticker),
+    enabled: !!ticker && assetType === 'etf',
+  });
+}
+
+export function useMarketSummary() {
+  const setSummary = useMarketStore((s) => s.setSummary);
+
+  return useQuery<MarketSummary>({
+    queryKey: ['market-summary'],
+    queryFn: async () => {
+      const data = await apiClient.getMarketSummary();
+      setSummary(data);
+      return data;
+    },
+  });
+}

--- a/web/src/hooks/use-user.ts
+++ b/web/src/hooks/use-user.ts
@@ -1,0 +1,30 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/lib/api-client';
+import { toast } from '@/lib/toast';
+import type { User } from '@/types/user';
+
+export function useCurrentUser() {
+  return useQuery<User>({
+    queryKey: ['user'],
+    queryFn: () => apiClient.getMe(),
+  });
+}
+
+export function useUpdateProfile() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (displayName: string) =>
+      apiClient.request('/api/v1/auth/me', {
+        method: 'PUT',
+        body: JSON.stringify({ display_name: displayName }),
+      }),
+    onSuccess: () => {
+      toast.success('Profile updated');
+      queryClient.invalidateQueries({ queryKey: ['user'] });
+    },
+    onError: () => {
+      toast.error('Failed to update profile');
+    },
+  });
+}

--- a/web/src/hooks/use-watchlist.ts
+++ b/web/src/hooks/use-watchlist.ts
@@ -1,0 +1,65 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/lib/api-client';
+import { toast } from '@/lib/toast';
+
+export function useWatchlist() {
+  return useQuery<string[]>({
+    queryKey: ['watchlist'],
+    queryFn: async () => {
+      const data = await apiClient.getWatchlist();
+      return data || [];
+    },
+  });
+}
+
+export function useAddToWatchlist() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (ticker: string) => apiClient.addToWatchlist(ticker),
+    onMutate: async (ticker) => {
+      await queryClient.cancelQueries({ queryKey: ['watchlist'] });
+      const previous = queryClient.getQueryData<string[]>(['watchlist']);
+      queryClient.setQueryData<string[]>(['watchlist'], (old) =>
+        old ? [...old, ticker] : [ticker]
+      );
+      return { previous };
+    },
+    onError: (_err, _ticker, context) => {
+      queryClient.setQueryData(['watchlist'], context?.previous);
+      toast.error('Failed to add to watchlist');
+    },
+    onSuccess: (_data, ticker) => {
+      toast.success(`${ticker} added to watchlist`);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['watchlist'] });
+    },
+  });
+}
+
+export function useRemoveFromWatchlist() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (ticker: string) => apiClient.removeFromWatchlist(ticker),
+    onMutate: async (ticker) => {
+      await queryClient.cancelQueries({ queryKey: ['watchlist'] });
+      const previous = queryClient.getQueryData<string[]>(['watchlist']);
+      queryClient.setQueryData<string[]>(['watchlist'], (old) =>
+        old?.filter((t) => t !== ticker)
+      );
+      return { previous };
+    },
+    onError: (_err, _ticker, context) => {
+      queryClient.setQueryData(['watchlist'], context?.previous);
+      toast.error('Failed to remove from watchlist');
+    },
+    onSuccess: (_data, ticker) => {
+      toast.success(`${ticker} removed from watchlist`);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['watchlist'] });
+    },
+  });
+}

--- a/web/src/lib/__tests__/formatters.test.ts
+++ b/web/src/lib/__tests__/formatters.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { formatCurrency, formatPercent, formatCompact, formatVolume, priceChangeColor, priceChangeBg } from '../formatters';
+
+describe('formatCurrency', () => {
+  it('formats numbers as USD', () => {
+    expect(formatCurrency(1234.56)).toBe('$1,234.56');
+    expect(formatCurrency(0)).toBe('$0.00');
+  });
+
+  it('handles string input', () => {
+    expect(formatCurrency('155.50')).toBe('$155.50');
+  });
+
+  it('formats negative values', () => {
+    expect(formatCurrency(-500)).toBe('-$500.00');
+  });
+});
+
+describe('formatPercent', () => {
+  it('adds + sign for positive values', () => {
+    expect(formatPercent(5.25)).toBe('+5.25%');
+  });
+
+  it('shows - sign for negative values', () => {
+    expect(formatPercent(-3.1)).toBe('-3.10%');
+  });
+
+  it('handles zero', () => {
+    expect(formatPercent(0)).toBe('+0.00%');
+  });
+
+  it('handles string input', () => {
+    expect(formatPercent('12.5')).toBe('+12.50%');
+  });
+});
+
+describe('formatCompact', () => {
+  it('formats billions', () => {
+    expect(formatCompact(2500000000)).toBe('$2.5B');
+  });
+
+  it('formats millions', () => {
+    expect(formatCompact(1500000)).toBe('$1.5M');
+  });
+
+  it('formats thousands', () => {
+    expect(formatCompact(45000)).toBe('$45.0K');
+  });
+
+  it('falls back to formatCurrency for small values', () => {
+    expect(formatCompact(500)).toBe('$500.00');
+  });
+});
+
+describe('formatVolume', () => {
+  it('formats millions', () => {
+    expect(formatVolume(1250000)).toBe('1.3M');
+  });
+
+  it('formats thousands', () => {
+    expect(formatVolume(5000)).toBe('5.0K');
+  });
+
+  it('returns raw number for small values', () => {
+    expect(formatVolume(500)).toBe('500');
+  });
+});
+
+describe('priceChangeColor', () => {
+  it('returns green for positive', () => {
+    expect(priceChangeColor(5)).toBe('text-emerald-400');
+  });
+
+  it('returns red for negative', () => {
+    expect(priceChangeColor(-3)).toBe('text-red-400');
+  });
+
+  it('returns gray for zero', () => {
+    expect(priceChangeColor(0)).toBe('text-gray-400');
+  });
+
+  it('handles string input', () => {
+    expect(priceChangeColor('1.5')).toBe('text-emerald-400');
+    expect(priceChangeColor('-0.5')).toBe('text-red-400');
+  });
+});
+
+describe('priceChangeBg', () => {
+  it('returns green bg for positive', () => {
+    expect(priceChangeBg(5)).toContain('emerald');
+  });
+
+  it('returns red bg for negative', () => {
+    expect(priceChangeBg(-3)).toContain('red');
+  });
+});

--- a/web/src/lib/__tests__/schemas.test.ts
+++ b/web/src/lib/__tests__/schemas.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { tradeSchema, orderSchema, alertSchema, profileSchema } from '../schemas';
+
+describe('tradeSchema', () => {
+  it('accepts valid shares', () => {
+    const result = tradeSchema.safeParse({ shares: 10 });
+    expect(result.success).toBe(true);
+  });
+
+  it('coerces string to number', () => {
+    const result = tradeSchema.safeParse({ shares: '25' });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.shares).toBe(25);
+  });
+
+  it('rejects zero shares', () => {
+    const result = tradeSchema.safeParse({ shares: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects negative shares', () => {
+    const result = tradeSchema.safeParse({ shares: -5 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-integer shares', () => {
+    const result = tradeSchema.safeParse({ shares: 1.5 });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('orderSchema', () => {
+  it('accepts valid limit order', () => {
+    const result = orderSchema.safeParse({
+      ticker: 'PIPE',
+      side: 'buy',
+      order_type: 'limit',
+      shares: 10,
+      limit_price: '150.00',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts valid stop order', () => {
+    const result = orderSchema.safeParse({
+      ticker: 'PIPE',
+      side: 'sell',
+      order_type: 'stop',
+      shares: 5,
+      stop_price: '140.00',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts valid stop_limit order', () => {
+    const result = orderSchema.safeParse({
+      ticker: 'PIPE',
+      side: 'buy',
+      order_type: 'stop_limit',
+      shares: 10,
+      limit_price: '150.00',
+      stop_price: '145.00',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects limit order without limit_price', () => {
+    const result = orderSchema.safeParse({
+      ticker: 'PIPE',
+      side: 'buy',
+      order_type: 'limit',
+      shares: 10,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects stop order without stop_price', () => {
+    const result = orderSchema.safeParse({
+      ticker: 'PIPE',
+      side: 'sell',
+      order_type: 'stop',
+      shares: 5,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty ticker', () => {
+    const result = orderSchema.safeParse({
+      ticker: '',
+      side: 'buy',
+      order_type: 'limit',
+      shares: 10,
+      limit_price: '100.00',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('alertSchema', () => {
+  it('accepts valid alert', () => {
+    const result = alertSchema.safeParse({
+      ticker: 'PIPE',
+      condition: 'above',
+      target_price: '160.00',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid price format', () => {
+    const result = alertSchema.safeParse({
+      ticker: 'PIPE',
+      condition: 'below',
+      target_price: 'abc',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty target price', () => {
+    const result = alertSchema.safeParse({
+      ticker: 'PIPE',
+      condition: 'above',
+      target_price: '',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('profileSchema', () => {
+  it('accepts valid name', () => {
+    const result = profileSchema.safeParse({ display_name: 'TraderJoe' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects empty name', () => {
+    const result = profileSchema.safeParse({ display_name: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects name over 30 chars', () => {
+    const result = profileSchema.safeParse({ display_name: 'a'.repeat(31) });
+    expect(result.success).toBe(false);
+  });
+});

--- a/web/src/lib/api-client.ts
+++ b/web/src/lib/api-client.ts
@@ -64,6 +64,10 @@ class APIClient {
     return this.request<any[]>(`/api/v1/stocks/${ticker}/history?interval=${interval}`);
   }
 
+  getETFHoldings(ticker: string) {
+    return this.request<any[]>(`/api/v1/stocks/${ticker}/holdings`);
+  }
+
   getMarketSummary() {
     return this.request<any>('/api/v1/stocks/market-summary');
   }

--- a/web/src/lib/cn.ts
+++ b/web/src/lib/cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/web/src/lib/schemas.ts
+++ b/web/src/lib/schemas.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+
+export const tradeSchema = z.object({
+  shares: z.coerce.number().int().positive('Enter a valid number of shares'),
+});
+
+export type TradeFormValues = z.infer<typeof tradeSchema>;
+
+export const orderSchema = z
+  .object({
+    ticker: z.string().min(1, 'Ticker is required').max(6).toUpperCase(),
+    side: z.enum(['buy', 'sell']),
+    order_type: z.enum(['limit', 'stop', 'stop_limit']),
+    shares: z.coerce.number().int().positive('Enter a valid number of shares'),
+    limit_price: z.string().optional(),
+    stop_price: z.string().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if ((data.order_type === 'limit' || data.order_type === 'stop_limit') && !data.limit_price) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Limit price is required',
+        path: ['limit_price'],
+      });
+    }
+    if ((data.order_type === 'stop' || data.order_type === 'stop_limit') && !data.stop_price) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Stop price is required',
+        path: ['stop_price'],
+      });
+    }
+  });
+
+export type OrderFormValues = z.infer<typeof orderSchema>;
+
+export const alertSchema = z.object({
+  ticker: z.string().min(1, 'Ticker is required').max(6).toUpperCase(),
+  condition: z.enum(['above', 'below']),
+  target_price: z.string().min(1, 'Target price is required').regex(/^\d+(\.\d{1,2})?$/, 'Invalid price'),
+});
+
+export type AlertFormValues = z.infer<typeof alertSchema>;
+
+export const profileSchema = z.object({
+  display_name: z.string().min(1, 'Name is required').max(30, 'Name is too long'),
+});
+
+export type ProfileFormValues = z.infer<typeof profileSchema>;

--- a/web/src/lib/toast.ts
+++ b/web/src/lib/toast.ts
@@ -1,0 +1,8 @@
+import { useToastStore } from '@/stores/toast-store';
+
+export const toast = {
+  success: (message: string) => useToastStore.getState().addToast(message, 'success'),
+  error: (message: string) => useToastStore.getState().addToast(message, 'error'),
+  info: (message: string) => useToastStore.getState().addToast(message, 'info'),
+  warning: (message: string) => useToastStore.getState().addToast(message, 'warning'),
+};

--- a/web/src/lib/websocket-client.ts
+++ b/web/src/lib/websocket-client.ts
@@ -1,4 +1,6 @@
 type MessageHandler = (data: any) => void;
+export type ConnectionStatus = 'connected' | 'reconnecting' | 'disconnected';
+type StatusHandler = (status: ConnectionStatus) => void;
 
 const WS_URL = process.env.NEXT_PUBLIC_WS_URL || 'ws://localhost:8080/ws';
 
@@ -8,6 +10,25 @@ export class WebSocketClient {
   private reconnectAttempts = 0;
   private maxReconnectAttempts = 10;
   private token: string | null = null;
+  private pingInterval: ReturnType<typeof setInterval> | null = null;
+  private _status: ConnectionStatus = 'disconnected';
+  private statusHandlers: StatusHandler[] = [];
+
+  get status() {
+    return this._status;
+  }
+
+  private setStatus(status: ConnectionStatus) {
+    this._status = status;
+    this.statusHandlers.forEach((h) => h(status));
+  }
+
+  onStatusChange(handler: StatusHandler) {
+    this.statusHandlers.push(handler);
+    return () => {
+      this.statusHandlers = this.statusHandlers.filter((h) => h !== handler);
+    };
+  }
 
   connect(token: string) {
     this.token = token;
@@ -15,6 +36,7 @@ export class WebSocketClient {
 
     this.ws.onopen = () => {
       this.reconnectAttempts = 0;
+      this.setStatus('connected');
       this.subscribe('market');
       this.subscribe('portfolio');
       this.startPing();
@@ -31,6 +53,7 @@ export class WebSocketClient {
     };
 
     this.ws.onclose = () => {
+      this.stopPing();
       this.attemptReconnect();
     };
 
@@ -40,8 +63,10 @@ export class WebSocketClient {
   }
 
   disconnect() {
+    this.stopPing();
     this.ws?.close();
     this.ws = null;
+    this.setStatus('disconnected');
   }
 
   subscribe(channel: string) {
@@ -73,16 +98,28 @@ export class WebSocketClient {
   }
 
   private attemptReconnect() {
-    if (this.reconnectAttempts >= this.maxReconnectAttempts || !this.token) return;
+    if (this.reconnectAttempts >= this.maxReconnectAttempts || !this.token) {
+      this.setStatus('disconnected');
+      return;
+    }
+    this.setStatus('reconnecting');
     this.reconnectAttempts++;
     const delay = Math.min(Math.pow(2, this.reconnectAttempts) * 1000, 30000);
     setTimeout(() => this.connect(this.token!), delay);
   }
 
   private startPing() {
-    setInterval(() => {
+    this.stopPing();
+    this.pingInterval = setInterval(() => {
       this.send({ type: 'ping' });
     }, 30000);
+  }
+
+  private stopPing() {
+    if (this.pingInterval) {
+      clearInterval(this.pingInterval);
+      this.pingInterval = null;
+    }
   }
 }
 

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+const publicPaths = ['/login', '/'];
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const token = request.cookies.get('mockstarket_token')?.value;
+
+  // Allow public paths
+  if (publicPaths.includes(pathname)) {
+    // If logged in and on login page, redirect to market
+    if (token && pathname === '/login') {
+      return NextResponse.redirect(new URL('/market', request.url));
+    }
+    return NextResponse.next();
+  }
+
+  // Protect dashboard routes
+  if (!token) {
+    return NextResponse.redirect(new URL('/login', request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    '/((?!_next/static|_next/image|favicon.ico|api).*)',
+  ],
+};

--- a/web/src/stores/__tests__/auth-store.test.ts
+++ b/web/src/stores/__tests__/auth-store.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useAuthStore } from '../auth-store';
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => { store[key] = value; }),
+    removeItem: vi.fn((key: string) => { delete store[key]; }),
+    clear: vi.fn(() => { store = {}; }),
+  };
+})();
+Object.defineProperty(global, 'localStorage', { value: localStorageMock });
+
+describe('useAuthStore', () => {
+  beforeEach(() => {
+    useAuthStore.setState({ user: null, token: null, isLoading: true });
+    localStorageMock.clear();
+  });
+
+  it('sets token', () => {
+    useAuthStore.getState().setToken('test-token');
+    expect(useAuthStore.getState().token).toBe('test-token');
+  });
+
+  it('sets user', () => {
+    const user = {
+      id: 'u1',
+      firebase_uid: 'fb1',
+      display_name: 'Test',
+      is_guest: true,
+      created_at: '2026-01-01',
+      login_streak: 0,
+      longest_streak: 0,
+    };
+    useAuthStore.getState().setUser(user);
+    expect(useAuthStore.getState().user).toEqual(user);
+  });
+
+  it('signs out and clears localStorage', () => {
+    useAuthStore.setState({ user: { id: 'u1', firebase_uid: 'fb1', display_name: 'Test', is_guest: true, created_at: '2026-01-01', login_streak: 0, longest_streak: 0 }, token: 'abc' });
+    useAuthStore.getState().signOut();
+
+    expect(useAuthStore.getState().user).toBeNull();
+    expect(useAuthStore.getState().token).toBeNull();
+    expect(localStorageMock.removeItem).toHaveBeenCalledWith('mockstarket_token');
+  });
+});

--- a/web/src/stores/__tests__/market-store.test.ts
+++ b/web/src/stores/__tests__/market-store.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useMarketStore } from '../market-store';
+
+describe('useMarketStore', () => {
+  beforeEach(() => {
+    useMarketStore.setState({
+      stocks: [],
+      summary: null,
+      isLoading: false,
+      searchQuery: '',
+    });
+  });
+
+  it('sets stocks', () => {
+    const stocks = [
+      { ticker: 'PIPE', name: 'Piper', sector: 'Tech', asset_type: 'stock', base_price: '100', current_price: '110', day_open: '100', day_high: '115', day_low: '99', prev_close: '99', volume: 1000, volatility: '0.02' },
+    ];
+    useMarketStore.getState().setStocks(stocks);
+    expect(useMarketStore.getState().stocks).toEqual(stocks);
+  });
+
+  it('updates prices', () => {
+    useMarketStore.setState({
+      stocks: [
+        { ticker: 'PIPE', name: 'Piper', sector: 'Tech', asset_type: 'stock', base_price: '100', current_price: '100', day_open: '100', day_high: '100', day_low: '100', prev_close: '99', volume: 1000, volatility: '0.02' },
+      ],
+    });
+
+    useMarketStore.getState().updatePrices([
+      { ticker: 'PIPE', price: '115.00', change: '15.00', change_pct: '15.00', volume: 2000, high: '120', low: '95' },
+    ]);
+
+    const stock = useMarketStore.getState().stocks[0];
+    expect(stock.current_price).toBe('115.00');
+    expect(stock.day_high).toBe('120');
+    expect(stock.day_low).toBe('95');
+    expect(stock.volume).toBe(2000);
+  });
+
+  it('filters stocks by search query', () => {
+    useMarketStore.setState({
+      stocks: [
+        { ticker: 'PIPE', name: 'Piper Industries', sector: 'Tech', asset_type: 'stock', base_price: '100', current_price: '110', day_open: '100', day_high: '115', day_low: '99', prev_close: '99', volume: 1000, volatility: '0.02' },
+        { ticker: 'BREW', name: 'BrewCraft', sector: 'Consumer', asset_type: 'stock', base_price: '50', current_price: '48', day_open: '50', day_high: '51', day_low: '47', prev_close: '49', volume: 500, volatility: '0.03' },
+      ],
+      searchQuery: 'pipe',
+    });
+
+    const filtered = useMarketStore.getState().filteredStocks();
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].ticker).toBe('PIPE');
+  });
+
+  it('returns all stocks when search is empty', () => {
+    useMarketStore.setState({
+      stocks: [
+        { ticker: 'PIPE', name: 'Piper', sector: 'Tech', asset_type: 'stock', base_price: '100', current_price: '110', day_open: '100', day_high: '115', day_low: '99', prev_close: '99', volume: 1000, volatility: '0.02' },
+        { ticker: 'BREW', name: 'BrewCraft', sector: 'Consumer', asset_type: 'stock', base_price: '50', current_price: '48', day_open: '50', day_high: '51', day_low: '47', prev_close: '49', volume: 500, volatility: '0.03' },
+      ],
+      searchQuery: '',
+    });
+
+    expect(useMarketStore.getState().filteredStocks()).toHaveLength(2);
+  });
+
+  it('searches by name too', () => {
+    useMarketStore.setState({
+      stocks: [
+        { ticker: 'PIPE', name: 'Piper Industries', sector: 'Tech', asset_type: 'stock', base_price: '100', current_price: '110', day_open: '100', day_high: '115', day_low: '99', prev_close: '99', volume: 1000, volatility: '0.02' },
+        { ticker: 'BREW', name: 'BrewCraft', sector: 'Consumer', asset_type: 'stock', base_price: '50', current_price: '48', day_open: '50', day_high: '51', day_low: '47', prev_close: '49', volume: 500, volatility: '0.03' },
+      ],
+      searchQuery: 'brew',
+    });
+
+    const filtered = useMarketStore.getState().filteredStocks();
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].ticker).toBe('BREW');
+  });
+});

--- a/web/src/stores/__tests__/toast-store.test.ts
+++ b/web/src/stores/__tests__/toast-store.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useToastStore } from '../toast-store';
+
+describe('useToastStore', () => {
+  beforeEach(() => {
+    useToastStore.setState({ toasts: [] });
+    vi.useFakeTimers();
+  });
+
+  it('adds a toast', () => {
+    useToastStore.getState().addToast('Test message', 'success');
+    expect(useToastStore.getState().toasts).toHaveLength(1);
+    expect(useToastStore.getState().toasts[0].message).toBe('Test message');
+    expect(useToastStore.getState().toasts[0].type).toBe('success');
+  });
+
+  it('removes a toast by id', () => {
+    useToastStore.getState().addToast('Toast 1', 'info');
+    const id = useToastStore.getState().toasts[0].id;
+    useToastStore.getState().removeToast(id);
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+
+  it('auto-removes toast after duration', () => {
+    useToastStore.getState().addToast('Auto remove', 'warning', 2000);
+    expect(useToastStore.getState().toasts).toHaveLength(1);
+
+    vi.advanceTimersByTime(2000);
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+
+  it('supports multiple toasts', () => {
+    useToastStore.getState().addToast('First', 'success');
+    useToastStore.getState().addToast('Second', 'error');
+    useToastStore.getState().addToast('Third', 'info');
+    expect(useToastStore.getState().toasts).toHaveLength(3);
+  });
+});

--- a/web/src/stores/toast-store.ts
+++ b/web/src/stores/toast-store.ts
@@ -1,0 +1,36 @@
+import { create } from 'zustand';
+
+export type ToastType = 'success' | 'error' | 'info' | 'warning';
+
+export interface Toast {
+  id: string;
+  message: string;
+  type: ToastType;
+}
+
+interface ToastState {
+  toasts: Toast[];
+  addToast: (message: string, type: ToastType, duration?: number) => void;
+  removeToast: (id: string) => void;
+}
+
+export const useToastStore = create<ToastState>((set) => ({
+  toasts: [],
+
+  addToast: (message, type, duration = 4000) => {
+    const id = crypto.randomUUID();
+    set((state) => ({
+      toasts: [...state.toasts, { id, message, type }],
+    }));
+    setTimeout(() => {
+      set((state) => ({
+        toasts: state.toasts.filter((t) => t.id !== id),
+      }));
+    }, duration);
+  },
+
+  removeToast: (id) =>
+    set((state) => ({
+      toasts: state.toasts.filter((t) => t.id !== id),
+    })),
+}));

--- a/web/src/test/mocks/handlers.ts
+++ b/web/src/test/mocks/handlers.ts
@@ -1,0 +1,268 @@
+import { http, HttpResponse } from 'msw';
+
+const API_URL = 'http://localhost:8080';
+
+// Sample data
+export const mockStocks = [
+  {
+    ticker: 'PIPE',
+    name: 'Piper Industries',
+    sector: 'Technology',
+    asset_type: 'stock',
+    base_price: '150.00',
+    current_price: '155.50',
+    day_open: '150.00',
+    day_high: '158.00',
+    day_low: '149.00',
+    prev_close: '149.50',
+    volume: 1250000,
+    volatility: '0.02',
+    description: 'Leading tech company',
+  },
+  {
+    ticker: 'BREW',
+    name: 'BrewCraft Holdings',
+    sector: 'Consumer Goods',
+    asset_type: 'stock',
+    base_price: '45.00',
+    current_price: '43.20',
+    day_open: '45.00',
+    day_high: '45.50',
+    day_low: '42.80',
+    prev_close: '44.90',
+    volume: 800000,
+    volatility: '0.03',
+  },
+  {
+    ticker: 'GLDX',
+    name: 'Gold Standard ETF',
+    sector: 'Commodities',
+    asset_type: 'etf',
+    base_price: '200.00',
+    current_price: '205.00',
+    day_open: '200.00',
+    day_high: '206.00',
+    day_low: '199.00',
+    prev_close: '199.50',
+    volume: 500000,
+    volatility: '0.01',
+  },
+];
+
+export const mockMarketSummary = {
+  index_value: '12500.00',
+  index_change_pct: '1.25',
+  total_stocks: 3,
+  gainers: 2,
+  losers: 1,
+};
+
+export const mockPortfolio = {
+  portfolio: {
+    id: 'port-1',
+    user_id: 'user-1',
+    cash: '85000.00',
+    net_worth: '105000.00',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-04-01T00:00:00Z',
+  },
+  positions: [
+    {
+      id: 'pos-1',
+      portfolio_id: 'port-1',
+      ticker: 'PIPE',
+      shares: 100,
+      avg_cost: '150.00',
+      current_price: '155.50',
+      market_value: '15550.00',
+      pnl: '550.00',
+      pnl_pct: '3.67',
+    },
+  ],
+  net_worth: '105000.00',
+  invested: '15000.00',
+};
+
+export const mockTrades = [
+  {
+    id: 'trade-1',
+    user_id: 'user-1',
+    ticker: 'PIPE',
+    side: 'buy',
+    shares: 100,
+    price: '150.00',
+    total: '15000.00',
+    created_at: '2026-03-15T10:30:00Z',
+  },
+];
+
+export const mockOrders = [
+  {
+    id: 'order-1',
+    ticker: 'PIPE',
+    side: 'buy',
+    order_type: 'limit',
+    shares: 50,
+    limit_price: '145.00',
+    stop_price: null,
+    status: 'open',
+    created_at: '2026-04-01T08:00:00Z',
+  },
+];
+
+export const mockAlerts = [
+  {
+    id: 'alert-1',
+    ticker: 'PIPE',
+    condition: 'above',
+    target_price: '160.00',
+    triggered: false,
+    triggered_at: null,
+    created_at: '2026-04-01T09:00:00Z',
+  },
+  {
+    id: 'alert-2',
+    ticker: 'BREW',
+    condition: 'below',
+    target_price: '40.00',
+    triggered: true,
+    triggered_at: '2026-04-02T14:00:00Z',
+    created_at: '2026-04-01T09:00:00Z',
+  },
+];
+
+export const mockLeaderboard = [
+  { id: 1, user_id: 'user-1', display_name: 'TraderJoe', net_worth: '120000.00', total_return: '20.00', rank: 1, period: 'alltime' },
+  { id: 2, user_id: 'user-2', display_name: 'StockPro', net_worth: '110000.00', total_return: '10.00', rank: 2, period: 'alltime' },
+];
+
+export const mockUser = {
+  id: 'user-1',
+  firebase_uid: 'guest_abc123',
+  display_name: 'TestTrader',
+  avatar_url: null,
+  is_guest: true,
+  created_at: '2026-01-01T00:00:00Z',
+  login_streak: 5,
+  longest_streak: 12,
+};
+
+export const handlers = [
+  // Auth
+  http.post(`${API_URL}/api/v1/auth/guest`, () =>
+    HttpResponse.json(mockUser)
+  ),
+  http.get(`${API_URL}/api/v1/auth/me`, () =>
+    HttpResponse.json(mockUser)
+  ),
+  http.put(`${API_URL}/api/v1/auth/me`, () =>
+    HttpResponse.json({ status: 'updated' })
+  ),
+
+  // Stocks
+  http.get(`${API_URL}/api/v1/stocks`, () =>
+    HttpResponse.json(mockStocks)
+  ),
+  http.get(`${API_URL}/api/v1/stocks/market-summary`, () =>
+    HttpResponse.json(mockMarketSummary)
+  ),
+  http.get(`${API_URL}/api/v1/stocks/:ticker`, ({ params }) => {
+    const stock = mockStocks.find((s) => s.ticker === params.ticker);
+    if (!stock) return new HttpResponse(null, { status: 404 });
+    return HttpResponse.json(stock);
+  }),
+  http.get(`${API_URL}/api/v1/stocks/:ticker/history`, () =>
+    HttpResponse.json([])
+  ),
+
+  // Portfolio
+  http.get(`${API_URL}/api/v1/portfolio`, () =>
+    HttpResponse.json(mockPortfolio)
+  ),
+  http.get(`${API_URL}/api/v1/portfolio/history`, () =>
+    HttpResponse.json([])
+  ),
+
+  // Trades
+  http.post(`${API_URL}/api/v1/trades`, async ({ request }) => {
+    const body = (await request.json()) as { ticker: string; side: string; shares: number };
+    return HttpResponse.json({
+      id: 'trade-new',
+      user_id: 'user-1',
+      ticker: body.ticker,
+      side: body.side,
+      shares: body.shares,
+      price: '155.50',
+      total: String(body.shares * 155.5),
+      created_at: new Date().toISOString(),
+    });
+  }),
+  http.get(`${API_URL}/api/v1/trades`, () =>
+    HttpResponse.json(mockTrades)
+  ),
+
+  // Orders
+  http.get(`${API_URL}/api/v1/orders`, () =>
+    HttpResponse.json(mockOrders)
+  ),
+  http.post(`${API_URL}/api/v1/orders`, () =>
+    HttpResponse.json({ id: 'order-new', status: 'open' })
+  ),
+  http.delete(`${API_URL}/api/v1/orders/:id`, () =>
+    HttpResponse.json({ status: 'cancelled' })
+  ),
+
+  // Alerts
+  http.get(`${API_URL}/api/v1/alerts`, () =>
+    HttpResponse.json(mockAlerts)
+  ),
+  http.post(`${API_URL}/api/v1/alerts`, () =>
+    HttpResponse.json({ id: 'alert-new', status: 'created' })
+  ),
+  http.delete(`${API_URL}/api/v1/alerts/:id`, () =>
+    HttpResponse.json({ status: 'deleted' })
+  ),
+
+  // Leaderboard
+  http.get(`${API_URL}/api/v1/leaderboard`, () =>
+    HttpResponse.json(mockLeaderboard)
+  ),
+
+  // Achievements
+  http.get(`${API_URL}/api/v1/achievements`, () =>
+    HttpResponse.json([
+      { id: 'ach-1', name: 'First Trade', description: 'Execute your first trade', icon: '🎯', category: 'trading' },
+    ])
+  ),
+  http.get(`${API_URL}/api/v1/achievements/me`, () =>
+    HttpResponse.json([{ id: 'ua-1', achievement_id: 'ach-1', earned_at: '2026-03-01T00:00:00Z' }])
+  ),
+
+  // Challenges
+  http.get(`${API_URL}/api/v1/challenges/today`, () =>
+    HttpResponse.json({
+      challenge: {
+        id: 'ch-1',
+        date: '2026-04-06',
+        challenge_type: 'trade_count',
+        description: 'Execute 3 trades today',
+        reward_cash: '500.00',
+      },
+      progress: { completed: false, completed_at: null, claimed: false },
+    })
+  ),
+  http.post(`${API_URL}/api/v1/challenges/check`, () =>
+    HttpResponse.json({ completed: false })
+  ),
+
+  // Watchlist
+  http.get(`${API_URL}/api/v1/watchlist`, () =>
+    HttpResponse.json(['PIPE', 'BREW'])
+  ),
+  http.post(`${API_URL}/api/v1/watchlist`, () =>
+    HttpResponse.json({ status: 'added' })
+  ),
+  http.delete(`${API_URL}/api/v1/watchlist/:ticker`, () =>
+    HttpResponse.json({ status: 'removed' })
+  ),
+];

--- a/web/src/test/mocks/server.ts
+++ b/web/src/test/mocks/server.ts
@@ -1,0 +1,4 @@
+import { setupServer } from 'msw/node';
+import { handlers } from './handlers';
+
+export const server = setupServer(...handlers);

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,0 +1,11 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach, beforeAll, afterAll } from 'vitest';
+import { server } from './mocks/server';
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
+afterEach(() => {
+  cleanup();
+  server.resetHandlers();
+});
+afterAll(() => server.close());

--- a/web/src/test/test-utils.tsx
+++ b/web/src/test/test-utils.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, type RenderOptions } from '@testing-library/react';
+import type { ReactElement } from 'react';
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+}
+
+export function createWrapper() {
+  const queryClient = createTestQueryClient();
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    );
+  };
+}
+
+export function renderWithProviders(
+  ui: ReactElement,
+  options?: Omit<RenderOptions, 'wrapper'>
+) {
+  const queryClient = createTestQueryClient();
+  return {
+    ...render(ui, {
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      ),
+      ...options,
+    }),
+    queryClient,
+  };
+}

--- a/web/src/types/stock.ts
+++ b/web/src/types/stock.ts
@@ -2,6 +2,7 @@ export interface Stock {
   ticker: string;
   name: string;
   sector: string;
+  asset_type: string; // stock, etf, crypto, commodity
   base_price: string;
   current_price: string;
   day_open: string;
@@ -34,6 +35,13 @@ export interface PricePoint {
   volume: number;
   interval: string;
   recorded_at: string;
+}
+
+export interface ETFHolding {
+  ticker: string;
+  name: string;
+  weight: string;
+  price: string;
 }
 
 export interface MarketSummary {

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+    include: ['src/**/*.test.{ts,tsx}'],
+    css: false,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- **React Query migration**: All 9 dashboard pages migrated from manual `useEffect+useState` to `useQuery/useMutation` hooks with automatic caching, background refetching, and optimistic updates
- **Toast notification system**: Zustand-powered toast store with framer-motion animations and lucide-react icons for success/error/info/warning feedback
- **Form validation**: Zod schemas + react-hook-form on trade, order, alert, and profile forms with inline error display
- **WebSocket event handling**: Real-time toast notifications for `trade_executed`, `order_matched`, `alert_triggered`, `achievement_earned`, `challenge_completed` with automatic query invalidation; fixed ping interval memory leak; added connection status indicator
- **Watchlist page**: New `/watchlist` route with add/remove, stock search, and watchlist toggle on stock detail pages
- **Portfolio performance chart**: Area chart (lightweight-charts) showing net worth over time
- **UI polish**: Lucide-react icons replacing all emoji in sidebar/nav, framer-motion page transitions on all pages, loading skeletons replacing "Loading..." text, debounced market search, sortable table columns
- **Auth middleware**: Cookie-based Next.js middleware protecting dashboard routes

## Test plan
- [ ] Run `npm run build` in `/web` — should compile with 0 errors (14 pages + middleware)
- [ ] Start backend + web client, verify guest login flow sets cookie and redirects to `/market`
- [ ] Browse market, verify real-time price updates via WebSocket
- [ ] Execute a trade on stock detail page, verify toast notification appears
- [ ] Create/cancel an order, verify form validation and toast feedback
- [ ] Add/remove stocks from watchlist page and stock detail toggle
- [ ] Check portfolio page renders performance chart when history data exists
- [ ] Verify auth middleware redirects to `/login` when no cookie present
- [ ] Test responsive layout at mobile breakpoints (bottom nav, hidden columns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)